### PR TITLE
add a link to GitHub repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,5 @@ setup(
                      "strings to f-strings.",
     install_requires=get_requirements(),
     entry_points={"console_scripts": ["flynt=flynt:main"]},
-
+    url="https://github.com/ikamensh/flynt",
 )


### PR DESCRIPTION
I was looking for the source code, it was "hard" to find. This commit adds a link to the GitHub repository, this will be visible on PyPI for instance.