### PR TITLE
Add support to be used as pre-commit hook

### DIFF
--- a/src/flynt/__init__.py
+++ b/src/flynt/__init__.py
@@ -36,7 +36,7 @@ def main():
         "--upgrade", action="store_true", default=False, help="run pyupgrade on .py files"
     )
 
-    parser.add_argument("src", action="store", help="source file or directory")
+    parser.add_argument("src", action="store", nargs="+", help="source file(s) or directory")
 
     args = parser.parse_args()
 

--- a/src/flynt/__init__.py
+++ b/src/flynt/__init__.py
@@ -5,6 +5,7 @@ Learn more about f-strings at https://www.python.org/dev/peps/pep-0498/"""
 __version__ = "0.26"
 
 import argparse
+import sys
 
 from flynt.api import fstringify
 
@@ -36,17 +37,19 @@ def main():
         "--upgrade", action="store_true", default=False, help="run pyupgrade on .py files"
     )
 
+    parser.add_argument("--fail-on-change", action="store_true", default=False, help="Fail when changing files (for linting purposes)")
     parser.add_argument("src", action="store", nargs="+", help="source file(s) or directory")
 
     args = parser.parse_args()
 
-    fstringify(args.src,
-               verbose = args.verbose,
-               quiet = args.quiet,
-               multiline = not args.no_multiline,
-               len_limit = int(args.line_length),
-               pyup = args.upgrade)
+    return fstringify(args.src,
+                      verbose = args.verbose,
+                      quiet = args.quiet,
+                      multiline = not args.no_multiline,
+                      len_limit = int(args.line_length),
+                      pyup = args.upgrade,
+                      fail_on_changes=args.fail_on_change)
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -88,7 +88,6 @@ def fstringify_files(files, verbose, quiet, multiline, len_limit, pyup, original
 
         if verbose and not quiet:
             print(f"fstringifying {file_path}...{status}")
-
     total_time = round(time.time() - start_time, 3)
 
     if not quiet:
@@ -119,8 +118,10 @@ def fstringify_files(files, verbose, quiet, multiline, len_limit, pyup, original
         print("Thank you for using flynt. Upgrade more projects and recommend it to your colleagues!\n")
         print('_-_.'*25)
 
+    return changed_files
 
-def fstringify(files_or_paths, verbose, quiet, multiline, len_limit, pyup):
+
+def fstringify(files_or_paths, verbose, quiet, multiline, len_limit, pyup, fail_on_changes=False):
     """ determine if a directory or a single file was passed, and f-stringify it."""
 
     files = []
@@ -135,12 +136,17 @@ def fstringify(files_or_paths, verbose, quiet, multiline, len_limit, pyup):
         if os.path.isdir(abs_path):
             files.extend(astor.code_to_ast.find_py_files(abs_path))
         else:
-            files.append((os.path.dirname(abs_path), os.path.basename(abs_path)),)
+            files.append((os.path.dirname(abs_path), os.path.basename(abs_path)))
 
-    fstringify_files(files,
-                     verbose=verbose,
-                     quiet=quiet,
-                     multiline=multiline,
-                     len_limit=len_limit,
-                     pyup=pyup,
-                     original_arg=file_or_path)
+    status = fstringify_files(files,
+                              verbose=verbose,
+                              quiet=quiet,
+                              multiline=multiline,
+                              len_limit=len_limit,
+                              pyup=pyup,
+                              original_arg=file_or_path)
+
+    if fail_on_changes:
+        return status
+    else:
+        return 0

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -120,18 +120,22 @@ def fstringify_files(files, verbose, quiet, multiline, len_limit, pyup, original
         print('_-_.'*25)
 
 
-def fstringify(file_or_path, verbose, quiet, multiline, len_limit, pyup):
+def fstringify(files_or_paths, verbose, quiet, multiline, len_limit, pyup):
     """ determine if a directory or a single file was passed, and f-stringify it."""
-    abs_path = os.path.abspath(file_or_path)
 
-    if not os.path.exists(abs_path):
-        print(f"`{file_or_path}` not found")
-        sys.exit(1)
+    files = []
 
-    if os.path.isdir(abs_path):
-        files = astor.code_to_ast.find_py_files(abs_path)
-    else:
-        files = ((os.path.dirname(abs_path), os.path.basename(abs_path)),)
+    for file_or_path in files_or_paths:
+        abs_path = os.path.abspath(file_or_path)
+
+        if not os.path.exists(abs_path):
+            print(f"`{file_or_path}` not found")
+            sys.exit(1)
+
+        if os.path.isdir(abs_path):
+            files.extend(astor.code_to_ast.find_py_files(abs_path))
+        else:
+            files.append((os.path.dirname(abs_path), os.path.basename(abs_path)),)
 
     fstringify_files(files,
                      verbose=verbose,


### PR DESCRIPTION
Adds support so flynt can be used as a [pre-commit](https://pre-commit.com) hook.

- [x] Allow to pass in multiple files/directories

- [x] Return a non-zero value when files have been changed (activated through the `--fail-on-change` flag)