### PR TITLE
Create .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: flynt
+  name: flynt
+  description: "flynt: command line tool to automatically convertd .format(...) strings into Python 3.6+'s "f-strings"."
+  entry: flynt
+  language: python
+  language_version: python3.6
+  require_serial: true
+  types: [python]


### PR DESCRIPTION
In order to add flynt as a precommit  hook  adding a .pre-commit-hooks.yaml