### PR TITLE
feature: add an --exclude argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ optional arguments:
                         involving string literals) with f-strings. 
                         Available only if flynt is installed with
                         3.8+ interpreter.
-  -f, --fail-on-change      Fail when changing files (for linting purposes)
+  -f, --fail-on-change      Fail when changing files (for linting purposes)  --exclude EXCLUDE [EXCLUDE ...]
+                        source file(s) or directory to ignore
 ```
 
 ### Sample output of a successful run:

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -163,11 +163,16 @@ def _print_report(
 
 
 def fstringify(
-    files_or_paths, multiline, len_limit, fail_on_changes=False, transform_concat=False
+    files_or_paths,
+    multiline,
+    len_limit,
+    fail_on_changes=False,
+    transform_concat=False,
+    excluded_files_or_paths=None,
 ):
     """ determine if a directory or a single file was passed, and f-stringify it."""
 
-    files = _resolve_files(files_or_paths)
+    files = _resolve_files(files_or_paths, excluded_files_or_paths)
 
     status = fstringify_files(
         files,
@@ -182,10 +187,14 @@ def fstringify(
         return 0
 
 
-def _resolve_files(files_or_paths) -> List[str]:
+def _resolve_files(files_or_paths, excluded_files_or_paths=None) -> List[str]:
     """Resolve relative paths and directory names into a list of absolute paths to python files."""
 
     files = []
+    _blacklist = blacklist.copy()
+    if excluded_files_or_paths is not None:
+        _blacklist.update(set(excluded_files_or_paths))
+
     for file_or_path in files_or_paths:
 
         abs_path = os.path.abspath(file_or_path)
@@ -200,5 +209,5 @@ def _resolve_files(files_or_paths) -> List[str]:
         else:
             files.append(abs_path)
 
-        files = [f for f in files if all(b not in file_or_path for b in blacklist)]
+    files = [f for f in files if all(b not in f for b in _blacklist)]
     return files

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -187,7 +187,7 @@ def fstringify(
         return 0
 
 
-def _resolve_files(files_or_paths, excluded_files_or_paths=None) -> List[str]:
+def _resolve_files(files_or_paths, excluded_files_or_paths) -> List[str]:
     """Resolve relative paths and directory names into a list of absolute paths to python files."""
 
     files = []

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -16,7 +16,11 @@ def main():
 
     verbosity_group = parser.add_mutually_exclusive_group()
     verbosity_group.add_argument(
-        "-v", "--verbose", action="store_true", help="run with verbose output", default=False
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="run with verbose output",
+        default=False,
     )
     verbosity_group.add_argument(
         "-q", "--quiet", action="store_true", help="run without output", default=False
@@ -76,6 +80,12 @@ def main():
     parser.add_argument(
         "src", action="store", nargs="+", help="source file(s) or directory"
     )
+    parser.add_argument(
+        "--exclude",
+        action="store",
+        nargs="+",
+        help="source file(s) or directory to ignore",
+    )
 
     args = parser.parse_args()
 
@@ -92,6 +102,7 @@ def main():
 
     return fstringify(
         args.src,
+        excluded_files_or_paths=args.exclude,
         multiline=not args.no_multiline,
         len_limit=int(args.line_length),
         fail_on_changes=args.fail_on_change,


### PR DESCRIPTION
Hi ! Thanks for making this tools, I've been looking for something similar for a while.

In my application, I found it useful to have a user-defined blacklist, because the project I want to apply flynt to has internal copies of some deps, and we don't want our copies to diverge from the source.

I'm proposing the addition of an `--exclude` argument for this purpose.
Admittedly I haven't written any test for it yet and I suspect this first draft is fragile, but I'd be happy to add some if you think this belongs in the code.

An important note is that while working on this I found a bug in `api.py`, namely, I change the following line

```python
# before
files = [f for f in files if all(b not in file_or_path for b in blacklist)]
# after
files = [f for f in files if all(b not in f for b in blacklist)]
```

I also changed the indentation level of this line so that the filtering is only performed once.

Let me know if there's anything I can do to enhance this contribution, cheers