### PR TITLE
add a --version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ optional arguments:
   -a, --aggressive      Include conversions with potentially changed behavior.
   -e EXCLUDE [EXCLUDE ...], --exclude EXCLUDE [EXCLUDE ...]
                         ignore files with given strings in it's absolute path.
-
+  --version             Print the current version number and exit.
 ```
 
 ### Sample output of a successful run:

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -9,7 +9,7 @@ from flynt import __version__
 
 
 def main():
-    print(f"Running flynt v.{__version__}")
+
     parser = argparse.ArgumentParser(
         description=f"flynt v.{__version__}", add_help=True, epilog=__doc__
     )
@@ -96,11 +96,25 @@ def main():
     )
 
     parser.add_argument(
-        "src", action="store", nargs="+", help="source file(s) or directory"
+        "src", action="store", nargs="*", help="source file(s) or directory"
     )
 
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        default=False,
+        help="Print the current version number and exit."
+    )
     args = parser.parse_args()
 
+    if args.version:
+        print(__version__)
+        sys.exit(0)
+    elif not args.src:
+        print("flynt: error: the following arguments are required: src")
+        sys.exit(1)
+
+    print(f"Running flynt v.{__version__}")
     if args.dry_run:
         print("Running flynt in dry-run mode. No files will be changed.")
 

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -111,7 +111,7 @@ def main():
         print(__version__)
         sys.exit(0)
     elif not args.src:
-        print("flynt: error: the following arguments are required: src")
+        parser.print_usage()
         sys.exit(1)
 
     print(f"Running flynt v.{__version__}")

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -111,6 +111,7 @@ def main():
         print(__version__)
         sys.exit(0)
     elif not args.src:
+        print("flynt: error: the following arguments are required: src")
         parser.print_usage()
         sys.exit(1)
 


### PR DESCRIPTION
This adds a `--version` option to flynt.
To avoid collisions with the required positional argument `src`, this required a small workaround. Maybe there's a cleaner solution I'm not seeing.