### PR TITLE
Improve formatting of .format() with string literals inside it

### DIFF
--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -104,4 +104,19 @@ def joined_string(fmt_call: ast.Call) -> ast.JoinedStr:
             f"Some variables were never used: {var_map} - skipping conversion, it's a risk of bug."
         )
 
+    def fix_literals(segment):
+        if (isinstance(segment, ast.FormattedValue) and
+                segment.format_spec is None and
+                isinstance(segment.value, ast.Constant) and
+                isinstance(segment.value.value, str)):
+            return segment.value
+        return segment
+    new_segments = [fix_literals(e) for e in new_segments]
+
+    if all(
+            (isinstance(segment, ast.Constant) and
+             isinstance(segment.value, str))
+            for segment in new_segments):
+        return ast.Str(''.join(segment.value for segment in new_segments))
+
     return ast.JoinedStr(new_segments)

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -1,4 +1,5 @@
 import ast
+import sys
 import string
 from collections import deque
 
@@ -104,19 +105,29 @@ def joined_string(fmt_call: ast.Call) -> ast.JoinedStr:
             f"Some variables were never used: {var_map} - skipping conversion, it's a risk of bug."
         )
 
+    def is_literal_string(node):
+        if sys.version_info < (3, 8):
+            return isinstance(node, ast.Str)
+        else:
+            return (isinstance(node, ast.Constant) and
+                    isinstance(node.value, str))
+
+    def literal_string_value(node):
+        if sys.version_info < (3, 8):
+            return node.s
+        else:
+            return node.value
+
     def fix_literals(segment):
         if (isinstance(segment, ast.FormattedValue) and
                 segment.format_spec is None and
-                isinstance(segment.value, ast.Constant) and
-                isinstance(segment.value.value, str)):
+                is_literal_string(segment.value)):
             return segment.value
         return segment
     new_segments = [fix_literals(e) for e in new_segments]
 
-    if all(
-            (isinstance(segment, ast.Constant) and
-             isinstance(segment.value, str))
-            for segment in new_segments):
-        return ast.Str(''.join(segment.value for segment in new_segments))
+    if all(is_literal_string(segment)
+           for segment in new_segments):
+        return ast.Str(''.join(literal_string_value(segment) for segment in new_segments))
 
     return ast.JoinedStr(new_segments)

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -17,6 +17,7 @@ all_files = pytest.fixture(
         "implicit_concat_named2.py",
         "indexed_fmt_name.py",
         "indexed_percent.py",
+        "literal_string.py",
         "long.py",
         "multiline.py",
         "multiline_1.py",

--- a/test/integration/expected_out/literal_string.py
+++ b/test/integration/expected_out/literal_string.py
@@ -1,0 +1,7 @@
+n = 5
+x = f"{n} hello, world"
+x = f"{n} non-str {True}"
+x = f"{n} with quote \"x\""
+
+x = "hello, world"
+x = "with quote \"x\""

--- a/test/integration/expected_out_single_line/literal_string.py
+++ b/test/integration/expected_out_single_line/literal_string.py
@@ -1,0 +1,7 @@
+n = 5
+x = f"{n} hello, world"
+x = f"{n} non-str {True}"
+x = f"{n} with quote \"x\""
+
+x = "hello, world"
+x = "with quote \"x\""

--- a/test/integration/samples_in/literal_string.py
+++ b/test/integration/samples_in/literal_string.py
@@ -1,0 +1,7 @@
+n = 5
+x = "{} hello, {}".format(n, "world")
+x = "{} non-str {}".format(n, True)
+x = "{} with quote {}".format(n, '"x"')
+
+x = "hello, {}".format("world")
+x = "with quote {}".format('"x"')


### PR DESCRIPTION
Great job writing flynt! It works really well :smiley: 

One thing that was a bit annoying is that we had lines like this one in our codebase:

```python
x = "{}, {}".format(some_expression, "literal string")
```

Although this is quite bad, when it was rewritten it became more annoying:

```python
x = f"{some_expression}, {'literal string'}"
```

This change will make the original expression to be rewritten like this instead:

```python
x = f"{some expression}, literal_string"
```

Maybe it's something very specific to our codebase. But I'll open a PR anyway in case you're interested in putting this change into the upstream version.