### PR TITLE
Fix incorrectly parsed prefix with mapping keys

### DIFF
--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -13,8 +13,8 @@ FORMAT_GROUP_MATCH = f"[hlL]?([{FORMATS}])"
 
 PREFIX_GROUP = "[0-9]*[.]?[0-9]*"
 
-DICT_PATTERN = re.compile(rf"(%{PREFIX_GROUP}\([^)]+\){FORMAT_GROUP})")
-SPLIT_DICT_PATTERN = re.compile(rf"%({PREFIX_GROUP})\(([^)]+)\){FORMAT_GROUP_MATCH}")
+DICT_PATTERN = re.compile(rf"(%\([^)]+\){PREFIX_GROUP}{FORMAT_GROUP})")
+SPLIT_DICT_PATTERN = re.compile(rf"%\(([^)]+)\)({PREFIX_GROUP}){FORMAT_GROUP_MATCH}")
 VAR_KEY_PATTERN = re.compile(
     f"%({PREFIX_GROUP}){FORMAT_GROUP_MATCH}"
 )  # specs at https://docs.python.org/3/library/stdtypes.html#string-formatting
@@ -70,7 +70,7 @@ def transform_dict(node):
     matches = DICT_PATTERN.findall(format_str)
     spec = []
     for idx, m in enumerate(matches):
-        _, prefix, var_key, fmt_str, _ = SPLIT_DICT_PATTERN.split(m)
+        _, var_key, prefix, fmt_str, _ = SPLIT_DICT_PATTERN.split(m)
         if not var_key:
             raise FlyntException("could not find dict key")
         spec.append((prefix, var_key, fmt_str))

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -309,6 +309,13 @@ def test_percent_attr():
     assert out == s_expected
 
 
+def test_percent_dict_prefix():
+    s_in = """a = '%(?)s %(world).2f' % var"""
+    s_expected = """a = f"{var['?']} {var['world']:.2f}\""""
+
+    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+
+
 def test_legacy_fmtspec(aggressive):
     s_in = """d = '%i' % var"""
     s_expected = """d = f'{int(var)}'"""


### PR DESCRIPTION
The prefix for precision/width is in the wrong place for dictionary conversions. This means that in cases such as:
```python
r = "%(a)s %(b).2f %(c)s" % d
```
Only some of the mapping keys (the recognised ones) are converted silently leaving the output somewhat broken:
```python
r = f"{d['a']} %(b).2f {d['c']}"
```
This fixes the error by correcting the regex, and adds a test that fails without this change.

It should be noted that this doesn't remove the potential for a "passed" but incorrectly converted specifier completely, other cases with mapping keys will still cause the same error, which I filed in #89.


_Side Note: There seem to be many commits crept in over time without the pre-commits run - the default run of `black` left a lot of scattered diffs. I made my changes in isolation, but it might be worth a re-run of black on the whole repo so that people who aren't so comfortable in git will get clean results out of their pre-commits._