### PR TITLE
Catch UnicodeDecideError when reading file. Don't convert line endings on file read

### DIFF
--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -25,7 +25,7 @@ def _fstringify_file(
     def default_result():
         return False, 0, len(contents), len(contents)
 
-    with open(filename, encoding="utf-8") as f:
+    with open(filename, encoding="utf-8", newline="") as f:
         try:
             contents = f.read()
         except UnicodeDecodeError as e:

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -22,12 +22,16 @@ def _fstringify_file(
     :return: tuple: (changes_made, n_changes,
     length of original code, length of new code)
     """
-
-    with open(filename, encoding="utf-8") as f:
-        contents = f.read()
-
     def default_result():
         return False, 0, len(contents), len(contents)
+
+    with open(filename, encoding="utf-8") as f:
+        try:
+            contents = f.read()
+        except UnicodeDecodeError as e:
+            contents = ''
+            print(f'Exception while reading {filename}: {e}')
+            return default_result()
 
     try:
         ast_before = ast.parse(contents)

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -7,6 +7,7 @@ from flynt import api
 from flynt import state
 from flynt.api import _fstringify_file
 
+invalid_unicode = b"# This is not valid unicode: " + bytes([0xff, 0xff])
 
 @pytest.fixture()
 def formattable_file(tmpdir):
@@ -28,6 +29,17 @@ def py2_file(tmpdir):
     yield tmp_path
 
 
+@pytest.fixture()
+def invalid_unicode_file(tmpdir):
+    folder = os.path.dirname(__file__)
+    tmp_path = os.path.join(tmpdir, "invalid_unicode.py")
+
+    with open(tmp_path, "wb") as f:
+        f.write(invalid_unicode)
+
+    yield tmp_path
+
+
 def test_py2(py2_file):
 
     with open(py2_file) as f:
@@ -41,6 +53,15 @@ def test_py2(py2_file):
     assert not modified
     assert content_after == content_before
 
+
+def test_invalid_unicode(invalid_unicode_file):
+    modified, _, _, _ = _fstringify_file(invalid_unicode_file, True, 1000)
+
+    with open(invalid_unicode_file, "rb") as f:
+        content_after = f.read()
+
+    assert not modified
+    assert content_after == invalid_unicode
 
 def test_works(formattable_file):
 


### PR DESCRIPTION
1. Fixes an issue where flynt would crash with a UnicodeDecodeError if a file contained a bad Unicode sequence. The exception didn't say which file had a problem, making it hard to debug.
2. Fixes the fix in PR #88 (newlines need to be preserved on read as well as on write), and adds a test for it.

I had some trouble committing corrupted sample files to git, so the test generates a file instead.