### PR TITLE
fix KeyError on % {...} with reused key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Files generated during test
 test/integration/actual_out
+test/integration/actual_out_concat
 test/integration/actual_out_single_line
 
 # Python cache

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -94,7 +94,8 @@ def transform_dict(node):
             mapping[str(ast.literal_eval(k))] = v
 
         def make_fv(key: str):
-            return mapping[key]
+            # only allow reused keys when aggressive is on
+            return mapping[key] if state.aggressive else mapping.pop(key)
 
     else:
 

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -94,7 +94,7 @@ def transform_dict(node):
             mapping[str(ast.literal_eval(k))] = v
 
         def make_fv(key: str):
-            return mapping.pop(key)
+            return mapping[key]
 
     else:
 
@@ -112,11 +112,6 @@ def transform_dict(node):
         else:
             # no match means it's just a literal string
             segments.append(ast.Str(s=block.replace("%%", "%")))
-
-    if mapping:
-        raise FlyntException(
-            "Not all keys were matched - either a flynt error or original code error."
-        )
 
     return ast.JoinedStr(segments)
 

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -304,11 +304,18 @@ def test_double_percent_dict():
     assert process.fstringify_code_by_line(s_in)[0] == s_expected
 
 
-def test_percent_dict_reused_key():
-    s_in = """a = '%(?)s %(?)s' % {'?': var}"""
+percent_dict_reused_key = """a = '%(?)s %(?)s' % {'?': var}"""
+
+
+def test_percent_dict_reused_key_noop():
+    assert (process.fstringify_code_by_line(percent_dict_reused_key)[0] ==
+            percent_dict_reused_key)
+
+
+def test_percent_dict_reused_key_aggressive(aggressive):
     s_expected = """a = f'{var} {var}'"""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(percent_dict_reused_key)[0] == s_expected
 
 
 def test_percent_dict_name():

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -304,6 +304,13 @@ def test_double_percent_dict():
     assert process.fstringify_code_by_line(s_in)[0] == s_expected
 
 
+def test_percent_dict_reused_key():
+    s_in = """a = '%(?)s %(?)s' % {'?': var}"""
+    s_expected = """a = f'{var} {var}'"""
+
+    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+
+
 def test_percent_dict_name():
     s_in = """a = '%(?)s world' % var"""
     s_expected = """a = f"{var['?']} world\""""


### PR DESCRIPTION
Hi! I hit a `KeyError` on code like `"%(var)s %(var)s" % {'var': 'x'}`, which didn't get converted because it reuses a key, and flynt `pop()`s keys on their first use. This fixes that. Example exception below.

One drawback here is that flynt no longer detects keys in the dict that aren't used in the literal. Let me know if that's a deal breaker, and I can probably add it back along with this fix.

Thanks in advance!

```
Exception 'type' during conversion of code '"foo %(var)s %(var)s" % {'var': 'x'}'
Traceback (most recent call last):
  File "/Users/ryan/src/oauth-dropins/local/lib/python3.9/site-packages/flynt/transform/transform.py", line 29, in transform_chunk
    converted, changed, str_in_str = fstringify_node(copy.deepcopy(tree))
  File "/Users/ryan/src/oauth-dropins/local/lib/python3.9/site-packages/flynt/transform/FstringifyTransformer.py", line 91, in fstringify_node
    result = ft.visit(node)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ast.py", line 407, in visit
    return visitor(node)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ast.py", line 483, in generic_visit
    value = self.visit(value)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ast.py", line 407, in visit
    return visitor(node)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ast.py", line 492, in generic_visit
    new_node = self.visit(old_value)
  File "/opt/homebrew/Cellar/python@3.9/3.9.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/ast.py", line 407, in visit
    return visitor(node)
  File "/Users/ryan/src/oauth-dropins/local/lib/python3.9/site-packages/flynt/transform/FstringifyTransformer.py", line 80, in visit_BinOp
    result_node, str_in_str = transform_binop(node)
  File "/Users/ryan/src/oauth-dropins/local/lib/python3.9/site-packages/flynt/transform/percent_transformer.py", line 212, in transform_binop
    return transform_dict(node), False
  File "/Users/ryan/src/oauth-dropins/local/lib/python3.9/site-packages/flynt/transform/percent_transformer.py", line 110, in transform_dict
    fv = formatted_value(prefix, fmt_str, make_fv(var_key))
  File "/Users/ryan/src/oauth-dropins/local/lib/python3.9/site-packages/flynt/transform/percent_transformer.py", line 97, in make_fv
    return mapping.pop(key)
KeyError: 'var'
```