### PR TITLE
Add support for transforming static string joins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### unreleased
+
+*[Contributed by Aarni Koskela]* `--transform-joins` (`-tj`) will transform string join operations on static operands
+to an f-string.
+
 #### v.0.71
 
 Added support to configuration via file.

--- a/src/flynt/ast_chunk.py
+++ b/src/flynt/ast_chunk.py
@@ -40,7 +40,10 @@ class AstChunk:
         return QuoteTypes.double
 
     def __str__(self):
-        return astor.to_source(self.node)[1:-2]
+        src = astor.to_source(self.node).rstrip()
+        if src.startswith("(") and src.endswith(")"):
+            src = src[1:-1]
+        return src
 
     def __repr__(self):
         return f"AstChunk: {self}"

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -82,6 +82,15 @@ def run_flynt_cli():
     )
 
     parser.add_argument(
+        "-tj",
+        "--transform-joins",
+        action="store_true",
+        default=False,
+        help="Replace static joins (where the joiner is a string literal and the joinee is a static-length list) "
+        "with f-strings. Available only if flynt is installed with 3.8+ interpreter.",
+    )
+
+    parser.add_argument(
         "-f",
         "--fail-on-change",
         action="store_true",
@@ -131,6 +140,12 @@ def run_flynt_cli():
                 installed to a python3.8+ interpreter. Currently using {sys.version_info}."""
         )
 
+    if args.transform_joins and sys.version_info < (3, 8):
+        raise Exception(
+            f"""Transforming joins is only possible with flynt
+                installed to a python3.8+ interpreter. Currently using {sys.version_info}."""
+        )
+
     if args.string:
         set_global_state(args)
         converted, _ = fstringify_code_by_line(
@@ -171,6 +186,7 @@ def run_flynt_cli():
         len_limit=int(args.line_length),
         fail_on_changes=args.fail_on_change,
         transform_concat=args.transform_concats,
+        transform_join=args.transform_joins,
     )
 
 

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -112,7 +112,7 @@ class JoinTransformer:
                 converted = converted.replace("\\n", "\n")
             else:
                 lines_fit = (
-                    len("".join([converted, rest])) <= self.len_limit - chunk.start_idx
+                    len(f"{converted}{rest}") <= self.len_limit - chunk.start_idx
                 )
 
         else:

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -10,6 +10,7 @@ from flynt.format import get_quote_type
 from flynt.lexer import split
 from flynt.transform.transform import transform_chunk
 from flynt.string_concat import concat_candidates, transform_concat
+from flynt.static_join import join_candidates, transform_join
 
 noqa_regex = re.compile("#[ ]*noqa.*flynt")
 
@@ -172,6 +173,11 @@ def fstringify_concats(code: str, multiline=True, len_limit=88) -> Tuple[str, in
     return _transform_code(
         code, concat_candidates, transform_concat, multiline, len_limit
     )
+
+
+def fstringify_static_joins(code: str, multiline=True, len_limit=88) -> Tuple[str, int]:
+    """replace joins on static content with f-string expressions."""
+    return _transform_code(code, join_candidates, transform_join, multiline, len_limit)
 
 
 def _transform_code(

--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -16,6 +16,9 @@ invalid_conversions = 0
 concat_candidates = 0
 concat_changes = 0
 
+join_candidates = 0
+join_changes = 0
+
 # Backup of the initial state to support the tests, which should start with a clean state each time.
 # Note: this assumes that all state variables are immutable.
 _initial_state = dict(globals())

--- a/src/flynt/static_join/__init__.py
+++ b/src/flynt/static_join/__init__.py
@@ -1,1 +1,2 @@
 from flynt.static_join.candidates import join_candidates
+from flynt.static_join.transformer import transform_join

--- a/src/flynt/static_join/__init__.py
+++ b/src/flynt/static_join/__init__.py
@@ -1,0 +1,1 @@
+from flynt.static_join.candidates import join_candidates

--- a/src/flynt/static_join/candidates.py
+++ b/src/flynt/static_join/candidates.py
@@ -1,0 +1,35 @@
+import ast
+from typing import List
+
+from flynt import state
+from flynt.ast_chunk import AstChunk
+from flynt.static_join.utils import (
+    get_static_join_bits,
+)
+
+
+class JoinHound(ast.NodeVisitor):
+    def __init__(self):
+        super().__init__()
+        self.victims: List[AstChunk] = []
+
+    def visit_Call(self, node: ast.Call):
+        """
+        Finds all nodes that are joins with a static string literal
+        as the joiner and a static iterable as the joinee.
+        """
+        if get_static_join_bits(node) is not None:
+            self.victims.append(AstChunk(node))
+        else:
+            self.generic_visit(node)
+
+
+def join_candidates(code: str):
+    tree = ast.parse(code)
+
+    ch = JoinHound()
+    ch.visit(tree)
+
+    state.join_candidates += len(ch.victims)
+
+    return ch.victims

--- a/src/flynt/static_join/transformer.py
+++ b/src/flynt/static_join/transformer.py
@@ -1,0 +1,41 @@
+import ast
+from typing import Tuple
+
+from flynt.static_join.utils import get_static_join_bits
+from flynt.utils import ast_formatted_value, ast_string_node, fixup_transformed
+
+
+class JoinTransformer(ast.NodeTransformer):
+    def __init__(self):
+        super().__init__()
+        self.counter = 0
+
+    def visit_Call(self, node: ast.Call):
+        """
+        Transforms a static string join to an f-string.
+        """
+        res = get_static_join_bits(node)
+        if not res:
+            return self.generic_visit(node)
+        joiner, args = res
+        self.counter += 1
+        args_with_interleaved_joiner = []
+        for arg in args:
+            if isinstance(arg, ast.Str):
+                args_with_interleaved_joiner.append(arg)
+            else:
+                args_with_interleaved_joiner.append(ast_formatted_value(arg))
+            args_with_interleaved_joiner.append(ast_string_node(joiner))
+        args_with_interleaved_joiner.pop()  # remove the last joiner
+        if all(isinstance(arg, ast.Str) for arg in args_with_interleaved_joiner):
+            return ast.Str(s="".join(arg.s for arg in args_with_interleaved_joiner))
+        return ast.JoinedStr(args_with_interleaved_joiner)
+
+
+def transform_join(code: str, *args, **kwargs) -> Tuple[str, bool]:
+    tree = ast.parse(f"({code})")
+
+    jt = JoinTransformer()
+    jt.visit(tree)
+    new_code = fixup_transformed(tree)
+    return new_code, jt.counter > 0

--- a/src/flynt/static_join/utils.py
+++ b/src/flynt/static_join/utils.py
@@ -1,0 +1,34 @@
+import ast
+from typing import Optional, List, Tuple
+
+from flynt.utils import is_str_literal
+
+
+def get_joiner_from_static_join(func: ast.AST) -> Optional[str]:
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "join"
+        and is_str_literal(func.value)
+    ):
+        return ast.literal_eval(func.value)
+    return None
+
+
+def get_arguments_from_static_join(args: List[ast.AST]) -> Optional[List[ast.AST]]:
+    if len(args) == 1 and isinstance(args[0], (ast.List, ast.Tuple, ast.Set)):
+        elts = args[0].elts
+        if any(isinstance(elt, ast.Starred) for elt in elts):
+            # If there's a `*starred` element in the list, it's not valid.
+            return None
+        return elts
+    return None
+
+
+def get_static_join_bits(node: ast.Call) -> Optional[Tuple[str, List[ast.AST]]]:
+    joiner = get_joiner_from_static_join(node.func)
+    if joiner is None:
+        return None
+    args = get_arguments_from_static_join(node.args)
+    if args is None:
+        return None
+    return joiner, args

--- a/src/flynt/string_concat/candidates.py
+++ b/src/flynt/string_concat/candidates.py
@@ -3,11 +3,7 @@ from typing import List
 
 from flynt import state
 from flynt.ast_chunk import AstChunk
-
-
-def is_str_literal(node):
-    """Returns True if a node is a string literal. f-string is also a string literal."""
-    return isinstance(node, (ast.Str, ast.JoinedStr))
+from flynt.utils import is_str_literal
 
 
 def is_string_concat(node):

--- a/src/flynt/string_concat/transformer.py
+++ b/src/flynt/string_concat/transformer.py
@@ -1,37 +1,9 @@
 import ast
 from typing import List, Tuple
 
-import astor
-
-from flynt.exceptions import FlyntException
-from flynt.format import QuoteTypes, set_quote_type
 from flynt.string_concat.candidates import is_string_concat
 from flynt.string_concat.string_in_string import check_sns_depth
-from flynt.linting.fstr_lint import FstrInliner
-
-
-def ast_formatted_value(
-    val, fmt_str: str = None, conversion=None
-) -> ast.FormattedValue:
-    if isinstance(val, ast.FormattedValue):
-        return val
-
-    if astor.to_source(val)[0] == "{":
-        raise FlyntException(
-            "values starting with '{' are better left not transformed."
-        )
-
-    if fmt_str:
-        format_spec = ast.JoinedStr([ast_string_node(fmt_str.replace(":", ""))])
-    else:
-        format_spec = None
-
-    conversion = -1 if conversion is None else ord(conversion.replace("!", ""))
-    return ast.FormattedValue(value=val, conversion=conversion, format_spec=format_spec)
-
-
-def ast_string_node(string: str) -> ast.Str:
-    return ast.Str(s=string)
+from flynt.utils import ast_formatted_value, ast_string_node, fixup_transformed
 
 
 def unpack_binop(node: ast.BinOp) -> List[ast.AST]:
@@ -94,15 +66,6 @@ def transform_concat(code: str, *args, **kwargs) -> Tuple[str, bool]:
 
     ft = ConcatTransformer()
     ft.visit(tree)
-    il = FstrInliner()
-    il.visit(tree)
-
-    new_code = astor.to_source(tree)
-    if new_code[-1] == "\n":
-        new_code = new_code[:-1]
-
-    new_code = new_code.replace("\n", "\\n")
-    if new_code[:4] == 'f"""':
-        new_code = set_quote_type(new_code, QuoteTypes.double)
+    new_code = fixup_transformed(tree)
 
     return new_code, ft.counter > 0

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -4,28 +4,9 @@ import string
 from collections import deque
 from typing import Tuple, Union
 
-import astor
-
 from flynt import state
 from flynt.exceptions import FlyntException, ConversionRefused
-
-
-def ast_formatted_value(
-    val, fmt_str: str = None, conversion=None
-) -> ast.FormattedValue:
-
-    if astor.to_source(val)[0] == "{":
-        raise FlyntException(
-            "values starting with '{' are better left not transformed."
-        )
-
-    format_spec = ast.JoinedStr([ast_string_node(fmt_str)]) if fmt_str else None
-    conversion = -1 if conversion is None else ord(conversion.replace("!", ""))
-    return ast.FormattedValue(value=val, conversion=conversion, format_spec=format_spec)
-
-
-def ast_string_node(string: str) -> ast.Str:
-    return ast.Str(s=string)
+from flynt.utils import ast_formatted_value, ast_string_node
 
 
 def matching_call(node) -> bool:

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -1,0 +1,51 @@
+import ast
+from typing import Optional
+
+import astor
+
+from flynt.exceptions import FlyntException
+from flynt.format import set_quote_type, QuoteTypes
+from flynt.linting.fstr_lint import FstrInliner
+
+
+def is_str_literal(node):
+    """Returns True if a node is a string literal. f-string is also a string literal."""
+    return isinstance(node, (ast.Str, ast.JoinedStr))
+
+
+def ast_formatted_value(
+    val: ast.AST,
+    fmt_str: str = None,
+    conversion: Optional[str] = None,
+) -> ast.FormattedValue:
+    if isinstance(val, ast.FormattedValue):
+        return val
+
+    if astor.to_source(val)[0] == "{":
+        raise FlyntException(
+            "values starting with '{' are better left not transformed."
+        )
+
+    if fmt_str:
+        format_spec = ast.JoinedStr([ast_string_node(fmt_str)])
+    else:
+        format_spec = None
+
+    conversion = -1 if conversion is None else ord(conversion.replace("!", ""))
+    return ast.FormattedValue(value=val, conversion=conversion, format_spec=format_spec)
+
+
+def ast_string_node(string: str) -> ast.Str:
+    return ast.Str(s=string)
+
+
+def fixup_transformed(tree: ast.AST) -> str:
+    il = FstrInliner()
+    il.visit(tree)
+    new_code = astor.to_source(tree)
+    if new_code[-1] == "\n":
+        new_code = new_code[:-1]
+    new_code = new_code.replace("\n", "\\n")
+    if new_code[:4] == 'f"""':
+        new_code = set_quote_type(new_code, QuoteTypes.double)
+    return new_code

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -46,6 +46,6 @@ def fixup_transformed(tree: ast.AST) -> str:
     if new_code[-1] == "\n":
         new_code = new_code[:-1]
     new_code = new_code.replace("\n", "\\n")
-    if new_code[:4] == 'f"""':
+    if new_code[:4] == 'f"""' or new_code[:3] == "'''" or new_code[:3] == '"""':
         new_code = set_quote_type(new_code, QuoteTypes.double)
     return new_code

--- a/test/integration/expected_out/static_string_join.py
+++ b/test/integration/expected_out/static_string_join.py
@@ -1,0 +1,2 @@
+# Should not change unless explicitly requested
+foo = "x".join([1, 2, 3])

--- a/test/integration/expected_out_single_line/static_string_join.py
+++ b/test/integration/expected_out_single_line/static_string_join.py
@@ -1,0 +1,2 @@
+# Should not change unless explicitly requested
+foo = "x".join([1, 2, 3])

--- a/test/integration/samples_in/static_string_join.py
+++ b/test/integration/samples_in/static_string_join.py
@@ -1,0 +1,2 @@
+# Should not change unless explicitly requested
+foo = "x".join([1, 2, 3])

--- a/test/test_static_join/test_sj_candidates.py
+++ b/test/test_static_join/test_sj_candidates.py
@@ -1,0 +1,38 @@
+import ast
+import sys
+from typing import Tuple
+
+import pytest
+
+from flynt.static_join.candidates import JoinHound, join_candidates
+from test.test_static_join.utils import CASES
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="requires python3.8 or higher"
+)
+
+
+@pytest.fixture()
+def code_and_ok() -> Tuple[str, int]:
+    """
+    Fixture for generating a Python module from the test cases.
+    """
+    code = "\n".join(f"case{i} = {case}" for (i, (case, expected)) in enumerate(CASES))
+    expected_ok = len([expected for (case, expected) in CASES if expected is not None])
+    return code, expected_ok
+
+
+@pytest.mark.parametrize("method", ["hound", "api"])
+def test_find_victims(code_and_ok: Tuple[str, int], method: str):
+    code, expected_ok = code_and_ok
+    if method == "hound":
+        tree = ast.parse(code)
+        ch = JoinHound()
+        ch.visit(tree)
+        victims = ch.victims
+    elif method == "api":
+        victims = list(join_candidates(code))
+    else:
+        raise NotImplementedError("...")
+    assert len(victims) == expected_ok
+    assert all(".join" in str(v) for v in victims)

--- a/test/test_static_join/test_sj_transformer.py
+++ b/test/test_static_join/test_sj_transformer.py
@@ -1,0 +1,20 @@
+import sys
+from typing import Optional
+
+import pytest
+
+from flynt.static_join.transformer import transform_join
+from test.test_static_join.utils import CASES
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="requires python3.8 or higher"
+)
+
+
+@pytest.mark.parametrize("source, expected", CASES)
+def test_transform(source: str, expected: Optional[str]):
+    new, changed = transform_join(source)
+    if changed:
+        assert new == expected
+    else:
+        assert expected is None

--- a/test/test_static_join/utils.py
+++ b/test/test_static_join/utils.py
@@ -1,0 +1,16 @@
+CASES = [
+    ("'b'.join(['a', 'c'])", '"abc"'),
+    ("'blah'.join([thing, (thing - 1)])", 'f"{thing}blah{thing - 1}"'),
+    ("'blah'.join([blah.blah, blah.bleh])", 'f"{blah.blah}blah{blah.bleh}"'),
+    ("''.join([a, b, 'c'])", 'f"{a}{b}c"'),
+    ('" ".join([a, "World"])', 'f"{a} World"'),
+    ('"".join(["Finally, ", a, " World"])', 'f"Finally, {a} World"'),
+    ('"x".join(("1", "2", "3"))', '"1x2x3"'),  # all static
+    ('"x".join({"4", \'5\', "yee"})', '"4x5xyee"'),  # all static
+    ('"y".join([1, 2, 3])', 'f"{1}y{2}y{3}"'),
+    ('"a".join([b])', 'f"{b}"'),
+    ('a.join(["1", "2", "3"])', None),  # Not a static joiner
+    ('"a".join(a)', None),  # Not a static joinee
+    ('"a".join([a, a, *a])', None),  # Not a static length
+    ('"a".join([c for c in a])', None),  # comprehension should not be transformed (not a static length)
+]


### PR DESCRIPTION
This PR adds support for transforming static string join operations into f-strings.

IOW, 

```bash
$ flynt -tj -d test/test_static_join/victim.py
```

```diff
 a = "Hello"
-msg1 = " ".join([a, " World"])
-msg2 = "".join(["Finally, ", a, " World"])
-msg3 = "x".join(("1", "2", "3"))
-msg4 = "x".join({"4", "5", "yee"})
-msg5 = "y".join([1, 2, 3])  # Should be transformed
+msg1 = f"{a}  World"
+msg2 = f"Finally, {a} World"
+msg3 = "1x2x3"
+msg4 = "4x5xyee"
+msg5 = f"{1}y{2}y{3}"  # Should be transformed
 msg6 = a.join(["1", "2", "3"])  # Should not be transformed (not a static joiner)
 msg7 = "a".join(a)  # Should not be transformed (not a static joinee)
 msg8 = "a".join([a, a, *a])  # Should not be transformed (not a static length)
```