### PR TITLE
Drop support for end-of-life Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ F-Strings:
 
 ### Installation
 
-`pip install flynt`. It requires Python version 3.6+.
+`pip install flynt`. It requires Python version 3.7+.
 
 ### Usage
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -45,7 +44,7 @@ setup(
     long_description=(_DIR / "README.md").read_text().strip(),
     long_description_content_type="text/markdown",
     install_requires=get_requirements(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={"console_scripts": ["flynt=flynt:main"]},
     url="https://github.com/ikamensh/flynt",
     include_package_data=True,


### PR DESCRIPTION
This PR marks `flynt` as compatible with Python 3.7+ only, since Python 3.6 has been end-of-life since December 2021.