### PR TITLE
Allow disabling percent and format transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # Files generated during test
-test/integration/actual_out
-test/integration/actual_out_concat
-test/integration/actual_out_single_line
+test/integration/actual_out*
 
 # Python cache
 __pycache__/

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -21,7 +21,14 @@ blacklist = {".tox", "venv", "site-packages", ".eggs"}
 
 
 def _fstringify_file(
-    filename, multiline, len_limit, transform_concat=False, transform_join=False
+    filename: str,
+    multiline: bool,
+    len_limit: int,
+    *,
+    transform_concat: bool = False,
+    transform_format: bool = True,
+    transform_join: bool = False,
+    transform_percent: bool = True,
 ) -> Tuple[bool, int, int, int]:
     """
     :return: tuple: (changes_made, n_changes,
@@ -51,9 +58,16 @@ def _fstringify_file(
         return default_result()
 
     try:
-        new_code, changes = fstringify_code_by_line(
-            contents, multiline=multiline, len_limit=len_limit
-        )
+        new_code = contents
+        changes = 0
+        if transform_percent or transform_format:
+            new_code, changes = fstringify_code_by_line(
+                contents,
+                multiline=multiline,
+                len_limit=len_limit,
+                transform_percent=transform_percent,
+                transform_format=transform_format,
+            )
         if transform_concat:
             new_code, concat_changes = fstringify_concats(
                 new_code, multiline=multiline, len_limit=len_limit
@@ -119,8 +133,11 @@ def fstringify_files(
     files,
     multiline,
     len_limit,
-    transform_concat,
-    transform_join,
+    transform_concat: bool = False,
+    transform_join: bool = False,
+    *,
+    transform_format: bool = True,
+    transform_percent: bool = True,
 ):
     changed_files = 0
     total_charcount_original = 0
@@ -138,7 +155,9 @@ def fstringify_files(
             multiline,
             len_limit,
             transform_concat=transform_concat,
+            transform_format=transform_format,
             transform_join=transform_join,
+            transform_percent=transform_percent,
         )
         if changed:
             changed_files += 1
@@ -229,6 +248,8 @@ def fstringify(
     multiline: bool,
     len_limit: int,
     fail_on_changes: bool = False,
+    transform_percent: bool = True,
+    transform_format: bool = True,
     transform_concat: bool = False,
     transform_join: bool = False,
     excluded_files_or_paths: Optional[Collection[str]] = None,
@@ -241,6 +262,8 @@ def fstringify(
         files,
         multiline=multiline,
         len_limit=len_limit,
+        transform_percent=transform_percent,
+        transform_format=transform_format,
         transform_concat=transform_concat,
         transform_join=transform_join,
     )

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -73,6 +73,24 @@ def run_flynt_cli():
     )
 
     parser.add_argument(
+        "--no-tp",
+        "--no-transform-percent",
+        dest="transform_percent",
+        action="store_false",
+        default=True,
+        help="Don't transform % formatting to f-strings (default: do so)",
+    )
+
+    parser.add_argument(
+        "--no-tf",
+        "--no-transform-format",
+        dest="transform_format",
+        action="store_false",
+        default=True,
+        help="Don't transform .format formatting to f-strings (default: do so)",
+    )
+
+    parser.add_argument(
         "-tc",
         "--transform-concats",
         action="store_true",
@@ -185,6 +203,8 @@ def run_flynt_cli():
         multiline=not args.no_multiline,
         len_limit=int(args.line_length),
         fail_on_changes=args.fail_on_change,
+        transform_percent=args.transform_percent,
+        transform_format=args.transform_format,
         transform_concat=args.transform_concats,
         transform_join=args.transform_joins,
     )

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -1,5 +1,6 @@
 import math
 import re
+from functools import partial
 from typing import Callable, Tuple
 import string
 
@@ -161,10 +162,21 @@ class JoinTransformer:
             self.last_line += 1
 
 
-def fstringify_code_by_line(code: str, multiline=True, len_limit=88) -> Tuple[str, int]:
+def fstringify_code_by_line(
+    code: str,
+    multiline=True,
+    len_limit=88,
+    transform_percent: bool = True,
+    transform_format: bool = True,
+) -> Tuple[str, int]:
     """returns fstringified version of the code and amount of lines edited."""
+    phunk = partial(
+        transform_chunk,
+        transform_format=transform_format,
+        transform_percent=transform_percent,
+    )
     return _transform_code(
-        code, split.get_fstringify_chunks, transform_chunk, multiline, len_limit
+        code, split.get_fstringify_chunks, phunk, multiline, len_limit
     )
 
 

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -26,6 +26,14 @@ conversion_methods = {"r": "!r", "a": "!a", "s": None}
 integer_specificers = "dxXob"
 
 
+def is_percent_stringify(node: ast.BinOp) -> bool:
+    return (
+        isinstance(node.left, ast.Str)
+        and isinstance(node.op, ast.Mod)
+        and isinstance(node.right, tuple([ast.Tuple, ast.Dict, *supported_operands]))
+    )
+
+
 def formatted_value(fmt_prefix, fmt_spec, val):
     if fmt_spec in integer_specificers:
         fmt_prefix = fmt_prefix.replace(".", "0")

--- a/src/flynt/transform/transform.py
+++ b/src/flynt/transform/transform.py
@@ -12,13 +12,18 @@ from flynt.transform.FstringifyTransformer import fstringify_node
 
 
 def transform_chunk(
-    code: str, quote_type: str = QuoteTypes.triple_double
+    code: str,
+    quote_type: str = QuoteTypes.triple_double,
+    transform_percent: bool = True,
+    transform_format: bool = True,
 ) -> Tuple[str, bool]:
     """Convert a block of code to an f-string
 
     Args:
         code: The code to convert.
         quote_type: the quote type to use for the transformed result
+        transform_percent: whether to transform percent format strings
+        transform_format: whether to transform format calls
 
     Returns:
        Tuple: resulting code, boolean: was it changed?
@@ -26,7 +31,11 @@ def transform_chunk(
 
     try:
         tree = ast.parse(code)
-        converted, changed, str_in_str = fstringify_node(copy.deepcopy(tree))
+        converted, changed, str_in_str = fstringify_node(
+            copy.deepcopy(tree),
+            transform_percent=transform_percent,
+            transform_format=transform_format,
+        )
     except (SyntaxError, FlyntException, Exception) as e:
         if state.verbose:
             if isinstance(e, ConversionRefused):

--- a/test/integration/expected_out_enable_format_only/sample.py
+++ b/test/integration/expected_out_enable_format_only/sample.py
@@ -1,0 +1,3 @@
+var = 5
+a = "Test: %s" % var
+b = f"my string {var:.2f}"

--- a/test/integration/expected_out_enable_percent_only/sample.py
+++ b/test/integration/expected_out_enable_percent_only/sample.py
@@ -1,0 +1,3 @@
+var = 5
+a = f"Test: {var}"
+b = "my string {:.2f}".format(var)

--- a/test/integration/samples_in_enable/sample.py
+++ b/test/integration/samples_in_enable/sample.py
@@ -1,0 +1,3 @@
+var = 5
+a = "Test: %s" % var
+b = "my string {:.2f}".format(var)

--- a/test/integration/test_files.py
+++ b/test/integration/test_files.py
@@ -24,3 +24,20 @@ def test_fstringify_single_line(filename):
         out_suffix="_single_line",
     )
     assert out == expected
+
+
+@pytest.mark.parametrize("enable", ["percent_only", "format_only"])
+def test_fstringify_enables(enable):
+    out, expected = try_on_file(
+        "sample.py",
+        partial(
+            fstringify_code_by_line,
+            multiline=False,
+            len_limit=None,
+            transform_percent=(enable == "percent_only"),
+            transform_format=(enable == "format_only"),
+        ),
+        suffix="_enable",
+        out_suffix=f"_enable_{enable}",
+    )
+    assert out == expected

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -187,3 +187,15 @@ def test_fix_fstrings(s, expected):
     new, changed = transform_chunk(s)
     assert changed
     assert new == expected
+
+
+def test_disabled_transforms():
+    # Test that disabling transforms does disable them
+    assert not transform_chunk(
+        '"my string {:.2f}".format(var)',
+        transform_format=False,
+    )[1]
+    assert not transform_chunk(
+        '"my string {:.2f}" % var',
+        transform_percent=False,
+    )[1]


### PR DESCRIPTION
There are times when you'd just like to run the concatenation (or, with #141, static string join) fixes – this adds flags to disable the default transformations.