### PR TITLE
pre-commit: updates + isort + autoflake + bandit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,9 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - run: pip install pre-commit
-      - run: pre-commit --version
-      - run: pre-commit install
-      - run: pre-commit run
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,18 @@ repos:
     rev: 1.7.4
     hooks:
       - id: bandit  # See setup.cfg for args
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3
         exclude: test/integration/actual_out|test/integration/actual_out_single_line|test/integration/expected_out|test/integration/expected_out_single_line|test/integration/samples_in
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell  # See setup.cfg for args
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8  # See setup.cfg for args
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        exclude: test/integration/actual_out|test/integration/actual_out_single_line|test/integration/expected_out|test/integration/expected_out_single_line|test/integration/samples_in
+        exclude: test/integration/(actual|expected|samples).*
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,21 +1,21 @@
 repos:
--   repo: https://github.com/PyCQA/bandit
+  - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
       - id: bandit  # See setup.cfg for args
--   repo: https://github.com/ambv/black
+  - repo: https://github.com/ambv/black
     rev: 22.3.0
     hooks:
-    - id: black
-      language_version: python3
-      exclude: test/integration/actual_out|test/integration/actual_out_single_line|test/integration/expected_out|test/integration/expected_out_single_line|test/integration/samples_in
--   repo: https://github.com/codespell-project/codespell
+      - id: black
+        language_version: python3
+        exclude: test/integration/actual_out|test/integration/actual_out_single_line|test/integration/expected_out|test/integration/expected_out_single_line|test/integration/samples_in
+  - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
       - id: codespell  # See setup.cfg for args
--   repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
-    - id: flake8  # See setup.cfg for args
-      additional_dependencies:
-        - flake8-black
+      - id: flake8  # See setup.cfg for args
+        additional_dependencies:
+          - flake8-black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,13 @@ repos:
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:
-      - id: bandit  # See setup.cfg for args
+      - id: bandit
+        additional_dependencies:
+          - "bandit[toml]"
+        args:
+          - -c
+          - pyproject.toml
+        exclude: test/integration/(actual|expected|samples).*
   - repo: https://github.com/PyCQA/autoflake
     rev: v1.7.7
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,13 @@ repos:
     rev: 1.7.4
     hooks:
       - id: bandit  # See setup.cfg for args
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args:
+          - --profile=black
+        exclude: test/integration/(actual|expected|samples).*
   - repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,15 @@ repos:
     rev: 1.7.4
     hooks:
       - id: bandit  # See setup.cfg for args
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v1.7.7
+    hooks:
+      - id: autoflake
+        args:
+          - --in-place
+          - --remove-duplicate-keys
+          - --remove-all-unused-imports
+        exclude: test/integration/(actual|expected|samples).*
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,7 @@ path = "src/flynt/__init__.py"
 include = [
     "/src",
 ]
+
+[tool.bandit]
+exclude_dirs = ["test"]
+skips = ["B101"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[bandit]
-exclude: /test
-skip = B101
-
 [codespell]
 ignore-words-list = hass,thats
 

--- a/src/flynt/__init__.py
+++ b/src/flynt/__init__.py
@@ -5,3 +5,5 @@ Learn more about f-strings at https://www.python.org/dev/peps/pep-0498/"""
 __version__ = "0.77-beta"
 
 from flynt.cli import main
+
+__all__ = ["main", "__version__"]

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -4,8 +4,8 @@ import os
 import sys
 import time
 import traceback
-from typing import Tuple, List, Optional, Collection
 from difflib import unified_diff
+from typing import Collection, List, Optional, Tuple
 
 import astor
 

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -4,9 +4,8 @@ import argparse
 import sys
 import warnings
 
+from flynt import __version__, state
 from flynt.api import fstringify, fstringify_code_by_line
-from flynt import state
-from flynt import __version__
 from flynt.pyproject_finder import find_pyproject_toml, parse_pyproject_toml
 
 

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -1,17 +1,17 @@
 import math
 import re
+import string
 from functools import partial
 from typing import Callable, Tuple
-import string
 
 from flynt import lexer, state
 from flynt.exceptions import FlyntException
 from flynt.format import QuoteTypes as qt
 from flynt.format import get_quote_type
 from flynt.lexer import split
-from flynt.transform.transform import transform_chunk
-from flynt.string_concat import concat_candidates, transform_concat
 from flynt.static_join import join_candidates, transform_join
+from flynt.string_concat import concat_candidates, transform_concat
+from flynt.transform.transform import transform_chunk
 
 noqa_regex = re.compile("#[ ]*noqa.*flynt")
 

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -9,8 +9,10 @@ from flynt.exceptions import FlyntException
 from flynt.format import QuoteTypes as qt
 from flynt.format import get_quote_type
 from flynt.lexer import split
-from flynt.static_join import join_candidates, transform_join
-from flynt.string_concat import concat_candidates, transform_concat
+from flynt.static_join.candidates import join_candidates
+from flynt.static_join.transformer import transform_join
+from flynt.string_concat.candidates import concat_candidates
+from flynt.string_concat.transformer import transform_concat
 from flynt.transform.transform import transform_chunk
 
 noqa_regex = re.compile("#[ ]*noqa.*flynt")

--- a/src/flynt/pyproject_finder.py
+++ b/src/flynt/pyproject_finder.py
@@ -2,12 +2,12 @@
 https://github.com/psf/black/
 """
 
+import os
 import sys
 import warnings
 from functools import lru_cache
 from pathlib import Path
-import os
-from typing import Tuple, Optional, Dict, Any, Sequence
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 import tomli
 

--- a/src/flynt/static_join/__init__.py
+++ b/src/flynt/static_join/__init__.py
@@ -1,2 +1,0 @@
-from flynt.static_join.candidates import join_candidates
-from flynt.static_join.transformer import transform_join

--- a/src/flynt/static_join/candidates.py
+++ b/src/flynt/static_join/candidates.py
@@ -3,9 +3,7 @@ from typing import List
 
 from flynt import state
 from flynt.ast_chunk import AstChunk
-from flynt.static_join.utils import (
-    get_static_join_bits,
-)
+from flynt.static_join.utils import get_static_join_bits
 
 
 class JoinHound(ast.NodeVisitor):

--- a/src/flynt/static_join/utils.py
+++ b/src/flynt/static_join/utils.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Optional, List, Tuple
+from typing import List, Optional, Tuple
 
 from flynt.utils import is_str_literal
 

--- a/src/flynt/string_concat/__init__.py
+++ b/src/flynt/string_concat/__init__.py
@@ -1,2 +1,0 @@
-from flynt.string_concat.candidates import concat_candidates
-from flynt.string_concat.transformer import transform_concat

--- a/src/flynt/transform/FstringifyTransformer.py
+++ b/src/flynt/transform/FstringifyTransformer.py
@@ -2,9 +2,9 @@ import ast
 from typing import Tuple
 
 from flynt import state
-from flynt.transform.format_call_transforms import joined_string, matching_call
-from flynt.transform.percent_transformer import transform_binop, is_percent_stringify
 from flynt.linting.fstr_lint import FstrInliner
+from flynt.transform.format_call_transforms import joined_string, matching_call
+from flynt.transform.percent_transformer import is_percent_stringify, transform_binop
 
 
 class FstringifyTransformer(ast.NodeTransformer):

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -1,11 +1,11 @@
 import ast
-import sys
 import string
+import sys
 from collections import deque
 from typing import Tuple, Union
 
 from flynt import state
-from flynt.exceptions import FlyntException, ConversionRefused
+from flynt.exceptions import ConversionRefused, FlyntException
 from flynt.utils import ast_formatted_value, ast_string_node
 
 

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -2,9 +2,9 @@ import ast
 import re
 from collections import deque
 
-from flynt.exceptions import FlyntException, ConversionRefused
-from flynt.transform.format_call_transforms import ast_formatted_value, ast_string_node
 from flynt import state
+from flynt.exceptions import ConversionRefused, FlyntException
+from flynt.transform.format_call_transforms import ast_formatted_value, ast_string_node
 
 FORMATS = "diouxXeEfFgGcrsa"
 

--- a/src/flynt/transform/transform.py
+++ b/src/flynt/transform/transform.py
@@ -3,11 +3,9 @@ import copy
 import traceback
 from typing import Tuple
 
-import astor
-
 from flynt import state
-from flynt.exceptions import FlyntException, ConversionRefused
-from flynt.format import QuoteTypes, set_quote_type
+from flynt.exceptions import ConversionRefused, FlyntException
+from flynt.format import QuoteTypes
 from flynt.transform.FstringifyTransformer import fstringify_node
 from flynt.utils import fixup_transformed
 

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -5,7 +5,7 @@ import astor
 from astor.string_repr import pretty_string
 
 from flynt.exceptions import FlyntException
-from flynt.format import set_quote_type, QuoteTypes
+from flynt.format import QuoteTypes, set_quote_type
 from flynt.linting.fstr_lint import FstrInliner
 
 

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -3,8 +3,7 @@ import shutil
 
 import pytest
 
-from flynt import api
-from flynt import state
+from flynt import api, state
 from flynt.api import _fstringify_file
 
 # These "files" are byte-string constants instead of actual files to prevent e.g. Git or text editors from accidentally changing the encoding

--- a/test/integration/test_concat.py
+++ b/test/integration/test_concat.py
@@ -1,10 +1,10 @@
 """ Test str processors on actual file contents """
 import sys
+from test.integration.utils import concat_samples, try_on_file
 
 import pytest
 
-from flynt.process import fstringify_concats, fstringify_code_by_line
-from test.integration.utils import try_on_file, concat_samples
+from flynt.process import fstringify_code_by_line, fstringify_concats
 
 
 def fstringify_and_concats(code: str):

--- a/test/integration/test_files.py
+++ b/test/integration/test_files.py
@@ -1,10 +1,10 @@
 """ Test str processors on actual file contents """
 from functools import partial
+from test.integration.utils import samples, try_on_file
 
 import pytest
 
 from flynt.process import fstringify_code_by_line
-from test.integration.utils import try_on_file, samples
 
 
 @pytest.mark.parametrize("filename", samples)

--- a/test/integration/test_files_len_limit.py
+++ b/test/integration/test_files_len_limit.py
@@ -1,10 +1,10 @@
 """ Test str processors on actual file contents """
 from functools import partial
+from test.integration.utils import try_on_file
 
 import pytest
 
 from flynt.process import fstringify_concats
-from test.integration.utils import try_on_file
 
 
 @pytest.mark.parametrize("filename", ["multiline_limit.py"])

--- a/test/integration/utils.py
+++ b/test/integration/utils.py
@@ -32,7 +32,7 @@ def try_on_file(
     txt_in = (int_test_path / f"samples_in{suffix}" / filename).read_text()
     ex = (int_test_path / f"expected_out{out_suffix}" / filename).read_text()
     out, edits = func(txt_in)
-    out_path = (int_test_path / f"actual_out{out_suffix}" / filename)
+    out_path = int_test_path / f"actual_out{out_suffix}" / filename
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(out)
     return out, ex

--- a/test/test_pyproject.py
+++ b/test/test_pyproject.py
@@ -1,5 +1,6 @@
-from flynt.pyproject_finder import find_pyproject_toml, parse_pyproject_toml
 import os
+
+from flynt.pyproject_finder import find_pyproject_toml, parse_pyproject_toml
 
 pyproject_content = """
 [tool.flynt]

--- a/test/test_static_join/test_sj_candidates.py
+++ b/test/test_static_join/test_sj_candidates.py
@@ -1,11 +1,11 @@
 import ast
 import sys
+from test.test_static_join.utils import CASES
 from typing import Tuple
 
 import pytest
 
 from flynt.static_join.candidates import JoinHound, join_candidates
-from test.test_static_join.utils import CASES
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 8), reason="requires python3.8 or higher"

--- a/test/test_static_join/test_sj_transformer.py
+++ b/test/test_static_join/test_sj_transformer.py
@@ -1,10 +1,10 @@
 import sys
+from test.test_static_join.utils import CASES
 from typing import Optional
 
 import pytest
 
 from flynt.static_join.transformer import transform_join
-from test.test_static_join.utils import CASES
 
 pytestmark = pytest.mark.skipif(
     sys.version_info < (3, 8), reason="requires python3.8 or higher"

--- a/test/test_static_join/utils.py
+++ b/test/test_static_join/utils.py
@@ -12,5 +12,6 @@ CASES = [
     ('a.join(["1", "2", "3"])', None),  # Not a static joiner
     ('"a".join(a)', None),  # Not a static joinee
     ('"a".join([a, a, *a])', None),  # Not a static length
-    ('"a".join([c for c in a])', None),  # comprehension should not be transformed (not a static length)
+    # comprehension should not be transformed (not a static length)
+    ('"a".join([c for c in a])', None),
 ]

--- a/update_readme.py
+++ b/update_readme.py
@@ -31,7 +31,9 @@ def main():
     # Redirect the output,
     # disable argparse exiting the entire program when it prints help,
     # and patch the terminal size so we get the same output all the time
-    with contextlib.redirect_stdout(sio), contextlib.suppress(SystemExit), patch_terminal_size():
+    with contextlib.redirect_stdout(sio), contextlib.suppress(
+        SystemExit
+    ), patch_terminal_size():
         sys.argv = ["flynt", "--help"]
         run_flynt_cli()
     flynt_help = sio.getvalue()


### PR DESCRIPTION
This PR:

* updates pre-commit hooks using `pre-commit autoupdate`
* adds the `isort` import sorting lint
* adds the `autoflake` dead-code removal lint
* corrects the Bandit pre-commit configuration to be actually read (see https://github.com/PyCQA/bandit/issues/902)
* switches CI to use https://github.com/pre-commit/action