### PR TITLE
Use logging instead of global state + verbose

### DIFF
--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -1,6 +1,7 @@
 """This module parses the command line arguments and passes them to flynt.api.fstringify."""
 
 import argparse
+import logging
 import sys
 import warnings
 from typing import List, Optional
@@ -166,6 +167,11 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
                 installed to a python3.8+ interpreter. Currently using {sys.version_info}."""
         )
 
+    logging.basicConfig(
+        format="%(message)s",
+        level=(logging.DEBUG if args.verbose else logging.CRITICAL),
+    )
+
     if args.string:
         set_global_state(args)
         converted, _ = fstringify_code_by_line(
@@ -214,6 +220,5 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
 
 def set_global_state(args: argparse.Namespace) -> None:
     state.aggressive = args.aggressive
-    state.verbose = args.verbose
     state.quiet = args.quiet
     state.dry_run = args.dry_run

--- a/src/flynt/exceptions.py
+++ b/src/flynt/exceptions.py
@@ -2,7 +2,7 @@ class FlyntException(Exception):
     pass
 
 
-class ConversionRefused(Exception):
+class ConversionRefused(FlyntException):
     pass
 
 

--- a/src/flynt/lexer/split.py
+++ b/src/flynt/lexer/split.py
@@ -1,11 +1,12 @@
 import io
+import logging
 import tokenize
-import traceback
 from typing import Generator
 
-from flynt import state
 from flynt.lexer.Chunk import Chunk
 from flynt.lexer.PyToken import PyToken
+
+log = logging.getLogger(__name__)
 
 
 def get_chunks(code: str) -> Generator[Chunk, None, None]:
@@ -30,9 +31,10 @@ def get_chunks(code: str) -> Generator[Chunk, None, None]:
 
         yield chunk
     except tokenize.TokenError as e:
-        if state.verbose:
-            traceback.print_exc()
-            print(e)
+        log.error(
+            f"TokenError: {e}",
+            exc_info=True,
+        )
 
 
 def get_fstringify_chunks(code: str) -> Generator[Chunk, None, None]:

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -1,10 +1,11 @@
+import logging
 import math
 import re
 import string
 from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
-from flynt import lexer, state
+from flynt import lexer
 from flynt.ast_chunk import AstChunk
 from flynt.exceptions import FlyntException
 from flynt.format import QuoteTypes as qt
@@ -18,6 +19,8 @@ from flynt.string_concat.transformer import transform_concat
 from flynt.transform.transform import transform_chunk
 
 noqa_regex = re.compile("#[ ]*noqa.*flynt")
+
+log = logging.getLogger(__name__)
 
 
 class JoinTransformer:
@@ -125,12 +128,12 @@ class JoinTransformer:
         else:
             lines_fit = True
         if contract_lines and not lines_fit:
-            if state.verbose:
-                print(
-                    "Skipping conversion due to line length limit. "
-                    "Pass -ll 999 to increase it. "
-                    "(999 is an example, as number of characters.)"
-                )
+            log.warning(
+                "Skipping conversion of %s due to line length limit. "
+                "Pass -ll 999 to increase it. "
+                "(999 is an example, as number of characters.)",
+                str(chunk),
+            )
             return
 
         self.results.append(converted)

--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -1,6 +1,5 @@
 """This module contains global state of flynt application instance."""
 
-verbose = False
 quiet = False
 aggressive = False
 dry_run = False

--- a/src/flynt/string_concat/string_in_string.py
+++ b/src/flynt/string_concat/string_in_string.py
@@ -12,7 +12,9 @@ class SinSDetector(ast.NodeVisitor):
     def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
         self.sns_depth += 1
         if self.sns_depth > self.maxdepth:
-            raise StringEmbeddingTooDeep
+            raise StringEmbeddingTooDeep(
+                f"String embedding too deep: {self.sns_depth} > {self.maxdepth}"
+            )
 
         self.generic_visit(node)
         self.sns_depth -= 1

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -53,7 +53,7 @@ def formatted_value(
 
     if fmt_spec in conversion_methods:
         if not state.aggressive and fmt_prefix:
-            raise FlyntException(
+            raise ConversionRefused(
                 "Default text alignment has changed between percent fmt and fstrings. "
                 "Proceeding would result in changed code behaviour."
             )
@@ -66,7 +66,7 @@ def formatted_value(
             # assume built-in len always returns int
             if not _is_len_call(val):
                 if not state.aggressive:
-                    raise FlyntException(
+                    raise ConversionRefused(
                         "Skipping %d formatting - fstrings behave differently from % formatting."
                     )
                 val = ast.Call(
@@ -92,7 +92,7 @@ def transform_dict(node: ast.BinOp) -> ast.JoinedStr:
     format_str = node.left.s
     matches = DICT_PATTERN.findall(format_str)
     if len(matches) != len(ANY_DICT.findall(format_str)):
-        raise FlyntException("Some locations have unknown format modifiers.")
+        raise ConversionRefused("Some locations have unknown format modifiers.")
 
     spec = []
     for idx, m in enumerate(matches):

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -4,7 +4,7 @@ from typing import Optional
 import astor
 from astor.string_repr import pretty_string
 
-from flynt.exceptions import FlyntException
+from flynt.exceptions import ConversionRefused
 from flynt.format import QuoteTypes, set_quote_type
 from flynt.linting.fstr_lint import FstrInliner
 
@@ -44,7 +44,7 @@ def ast_formatted_value(
         return val
 
     if ast_to_string(val).startswith("{"):
-        raise FlyntException(
+        raise ConversionRefused(
             "values starting with '{' are better left not transformed."
         )
 


### PR DESCRIPTION
As part of my Secret Grand Plan (not really, I just revealed it) of getting rid of the global `state`, this switches `print()`s in non-"frontend" situations to `logging` calls.

<del>The</del> Verbose logging output may look different from before.