### PR TITLE
Get rid of global state

### DIFF
--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -1,30 +1,33 @@
 """This module contains global state of flynt application instance."""
 
-quiet = False
-aggressive = False
-dry_run = False
-
-percent_candidates = 0
-percent_transforms = 0
-
-call_candidates = 0
-call_transforms = 0
-
-invalid_conversions = 0
-
-concat_candidates = 0
-concat_changes = 0
-
-join_candidates = 0
-join_changes = 0
-
-# Backup of the initial state to support the tests, which should start with a clean state each time.
-# Note: this assumes that all state variables are immutable.
-_initial_state = dict(globals())
+import dataclasses
+from typing import Optional
 
 
-def _reset() -> None:
-    """
-    Resets the state variables to the initial values seen above.
-    """
-    globals().update(**_initial_state)
+@dataclasses.dataclass
+class State:
+    # -- Options
+    quiet: bool = False
+    aggressive: bool = False
+    dry_run: bool = False
+    multiline: bool = True
+    len_limit: Optional[int] = None
+    transform_percent: bool = True
+    transform_format: bool = True
+    transform_concat: bool = False
+    transform_join: bool = False
+
+    # -- Statistics
+    percent_candidates: int = 0
+    percent_transforms: int = 0
+
+    call_candidates: int = 0
+    call_transforms: int = 0
+
+    invalid_conversions: int = 0
+
+    concat_candidates: int = 0
+    concat_changes: int = 0
+
+    join_candidates: int = 0
+    join_changes: int = 0

--- a/src/flynt/static_join/candidates.py
+++ b/src/flynt/static_join/candidates.py
@@ -1,8 +1,8 @@
 import ast
 from typing import List
 
-from flynt import state
 from flynt.ast_chunk import AstChunk
+from flynt.state import State
 from flynt.static_join.utils import get_static_join_bits
 
 
@@ -22,7 +22,7 @@ class JoinHound(ast.NodeVisitor):
             self.generic_visit(node)
 
 
-def join_candidates(code: str):
+def join_candidates(code: str, state: State):
     tree = ast.parse(code)
 
     ch = JoinHound()

--- a/src/flynt/string_concat/candidates.py
+++ b/src/flynt/string_concat/candidates.py
@@ -1,8 +1,8 @@
 import ast
 from typing import Generator, List
 
-from flynt import state
 from flynt.ast_chunk import AstChunk
+from flynt.state import State
 from flynt.utils import is_str_literal
 
 
@@ -30,7 +30,7 @@ class ConcatHound(ast.NodeVisitor):
             self.generic_visit(node)
 
 
-def concat_candidates(code: str) -> Generator[AstChunk, None, None]:
+def concat_candidates(code: str, state: State) -> Generator[AstChunk, None, None]:
     tree = ast.parse(code)
 
     ch = ConcatHound()

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -4,7 +4,6 @@ import sys
 from collections import deque
 from typing import Any, Dict, List, Tuple, Union
 
-from flynt import state
 from flynt.exceptions import ConversionRefused, FlyntException
 from flynt.utils import ast_formatted_value, ast_string_node
 
@@ -26,7 +25,11 @@ def matching_call(node: ast.Call) -> bool:
 stdlib_parse = string.Formatter().parse
 
 
-def joined_string(fmt_call: ast.Call) -> Tuple[Union[ast.JoinedStr, ast.Str], bool]:
+def joined_string(
+    fmt_call: ast.Call,
+    *,
+    aggressive: bool = False,
+) -> Tuple[Union[ast.JoinedStr, ast.Str], bool]:
     """Transform a "...".format() call node into a f-string node."""
     assert isinstance(fmt_call.func, ast.Attribute) and isinstance(
         fmt_call.func.value, ast.Str
@@ -79,7 +82,7 @@ def joined_string(fmt_call: ast.Call) -> Tuple[Union[ast.JoinedStr, ast.Str], bo
         else:
             identifier = var_name
 
-        if state.aggressive:
+        if aggressive:
             ast_name = var_map[identifier]
         else:
             try:
@@ -94,7 +97,7 @@ def joined_string(fmt_call: ast.Call) -> Tuple[Union[ast.JoinedStr, ast.Str], bo
             ast_name = ast.Attribute(value=ast_name, attr=suffix)
         new_segments.append(ast_formatted_value(ast_name, fmt_str, conversion))
 
-    if var_map and not state.aggressive:
+    if var_map and not aggressive:
         raise FlyntException(
             f"Some variables were never used: {var_map} - skipping conversion, it's a risk of bug."
         )

--- a/src/flynt/transform/transform.py
+++ b/src/flynt/transform/transform.py
@@ -3,9 +3,9 @@ import copy
 import logging
 from typing import Tuple
 
-from flynt import state
 from flynt.exceptions import ConversionRefused
 from flynt.format import QuoteTypes
+from flynt.state import State
 from flynt.transform.FstringifyTransformer import fstringify_node
 from flynt.utils import fixup_transformed
 
@@ -14,17 +14,15 @@ log = logging.getLogger(__name__)
 
 def transform_chunk(
     code: str,
+    state: State,
     quote_type: str = QuoteTypes.triple_double,
-    transform_percent: bool = True,
-    transform_format: bool = True,
 ) -> Tuple[str, bool]:
     """Convert a block of code to an f-string
 
     Args:
+        state: State object, for settings and statistics
         code: The code to convert.
         quote_type: the quote type to use for the transformed result
-        transform_percent: whether to transform percent format strings
-        transform_format: whether to transform format calls
 
     Returns:
        Tuple: resulting code, boolean: was it changed?
@@ -34,8 +32,7 @@ def transform_chunk(
         tree = ast.parse(code)
         converted, changed, str_in_str = fstringify_node(
             copy.deepcopy(tree),
-            transform_percent=transform_percent,
-            transform_format=transform_format,
+            state=state,
         )
     except ConversionRefused as cr:
         log.warning("Not converting code '%s': %s", code, cr)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,11 +1,11 @@
 import pytest
 
-from flynt.state import _reset
+from flynt.state import State
 
 
-@pytest.fixture(autouse=True)
-def reset_state():
+@pytest.fixture
+def state() -> State:
     """
-    Fixture to reset the global state between each test
+    Fixture for a default state object
     """
-    _reset()
+    return State()

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -3,8 +3,9 @@ import shutil
 
 import pytest
 
-from flynt import api, state
+from flynt import api
 from flynt.api import _fstringify_file
+from flynt.state import State
 
 # These "files" are byte-string constants instead of actual files to prevent e.g. Git or text editors from accidentally changing the encoding
 invalid_unicode = b"# This is not valid unicode: " + bytes([0xFF, 0xFF])
@@ -60,7 +61,9 @@ def test_py2(py2_file):
     with open(py2_file) as f:
         content_before = f.read()
 
-    modified, _, _, _ = _fstringify_file(py2_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        py2_file, state=State(multiline=True, len_limit=1000)
+    )
 
     with open(py2_file) as f:
         content_after = f.read()
@@ -70,7 +73,9 @@ def test_py2(py2_file):
 
 
 def test_invalid_unicode(invalid_unicode_file):
-    modified, _, _, _ = _fstringify_file(invalid_unicode_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        invalid_unicode_file, state=State(multiline=True, len_limit=1000)
+    )
 
     with open(invalid_unicode_file, "rb") as f:
         content_after = f.read()
@@ -84,7 +89,9 @@ def test_works(formattable_file):
     with open(formattable_file) as f:
         content_before = f.read()
 
-    modified, _, _, _ = _fstringify_file(formattable_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        formattable_file, state=State(multiline=True, len_limit=1000)
+    )
 
     with open(formattable_file) as f:
         content_after = f.read()
@@ -103,7 +110,9 @@ def test_break_safe(formattable_file, monkeypatch):
 
     monkeypatch.setattr(api, "fstringify_code_by_line", broken_fstringify_by_line)
 
-    modified, _, _, _ = _fstringify_file(formattable_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        formattable_file, state=State(multiline=True, len_limit=1000)
+    )
 
     with open(formattable_file) as f:
         content_after = f.read()
@@ -122,7 +131,9 @@ def test_catches_subtle(formattable_file, monkeypatch):
 
     monkeypatch.setattr(api, "fstringify_code_by_line", broken_fstringify_by_line)
 
-    modified, _, _, _ = _fstringify_file(formattable_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        formattable_file, state=State(multiline=True, len_limit=1000)
+    )
 
     with open(formattable_file) as f:
         content_after = f.read()
@@ -132,11 +143,12 @@ def test_catches_subtle(formattable_file, monkeypatch):
 
 
 def test_dry_run(formattable_file, monkeypatch):
-    monkeypatch.setattr(state, "dry_run", True)
     with open(formattable_file) as f:
         content_before = f.read()
 
-    modified, _, _, _ = _fstringify_file(formattable_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        formattable_file, state=State(multiline=True, len_limit=1000, dry_run=True)
+    )
 
     with open(formattable_file) as f:
         content_after = f.read()
@@ -146,7 +158,9 @@ def test_dry_run(formattable_file, monkeypatch):
 
 
 def test_mixed_line_endings(mixed_line_endings_file):
-    modified, _, _, _ = _fstringify_file(mixed_line_endings_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        mixed_line_endings_file, state=State(multiline=True, len_limit=1000)
+    )
 
     with open(mixed_line_endings_file, "rb") as f:
         content_after = f.read()
@@ -170,5 +184,7 @@ def test_bom(bom_file):
 
     It's possible to verify that a file has bom using `file` unix utility."""
 
-    modified, _, _, _ = _fstringify_file(bom_file, True, 1000)
+    modified, _, _, _ = _fstringify_file(
+        bom_file, state=State(multiline=True, len_limit=1000)
+    )
     assert modified

--- a/test/integration/test_concat.py
+++ b/test/integration/test_concat.py
@@ -5,11 +5,13 @@ from test.integration.utils import concat_samples, try_on_file
 import pytest
 
 from flynt.process import fstringify_code_by_line, fstringify_concats
+from flynt.state import State
 
 
 def fstringify_and_concats(code: str):
-    code, count_a = fstringify_code_by_line(code, multiline=True, len_limit=None)
-    code, count_b = fstringify_concats(code, multiline=True, len_limit=None)
+    state = State()
+    code, count_a = fstringify_code_by_line(code, state=state)
+    code, count_b = fstringify_concats(code, state=state)
     return code, count_a + count_b
 
 

--- a/test/integration/test_files.py
+++ b/test/integration/test_files.py
@@ -5,22 +5,24 @@ from test.integration.utils import samples, try_on_file
 import pytest
 
 from flynt.process import fstringify_code_by_line
+from flynt.state import State
 
 
 @pytest.mark.parametrize("filename", samples)
-def test_fstringify(filename):
+def test_fstringify(filename, state):
     out, expected = try_on_file(
         filename,
-        partial(fstringify_code_by_line, multiline=True, len_limit=None),
+        partial(fstringify_code_by_line, state=state),
     )
     assert out == expected
 
 
 @pytest.mark.parametrize("filename", samples)
-def test_fstringify_single_line(filename):
+def test_fstringify_single_line(filename, state: State):
+    state.multiline = False
     out, expected = try_on_file(
         filename,
-        partial(fstringify_code_by_line, multiline=False, len_limit=None),
+        partial(fstringify_code_by_line, state=state),
         out_suffix="_single_line",
     )
     assert out == expected
@@ -28,14 +30,17 @@ def test_fstringify_single_line(filename):
 
 @pytest.mark.parametrize("enable", ["percent_only", "format_only"])
 def test_fstringify_enables(enable):
+    state = State(
+        multiline=False,
+        len_limit=None,
+        transform_percent=(enable == "percent_only"),
+        transform_format=(enable == "format_only"),
+    )
     out, expected = try_on_file(
         "sample.py",
         partial(
             fstringify_code_by_line,
-            multiline=False,
-            len_limit=None,
-            transform_percent=(enable == "percent_only"),
-            transform_format=(enable == "format_only"),
+            state=state,
         ),
         suffix="_enable",
         out_suffix=f"_enable_{enable}",

--- a/test/integration/test_files_len_limit.py
+++ b/test/integration/test_files_len_limit.py
@@ -8,9 +8,9 @@ from flynt.process import fstringify_concats
 
 
 @pytest.mark.parametrize("filename", ["multiline_limit.py"])
-def test_fstringify(filename):
+def test_fstringify(filename, state):
     out, expected = try_on_file(
         filename,
-        partial(fstringify_concats, multiline=True, len_limit=None),
+        partial(fstringify_concats, state=state),
     )
     assert out == expected

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -2,183 +2,180 @@ import sys
 
 import pytest
 
-from flynt import process, state
+from flynt import process
+from flynt.state import State
 
 
-@pytest.fixture()
-def aggressive(monkeypatch):
-    monkeypatch.setattr(state, "aggressive", True)
-    yield
-
-
-def test_timestamp():
+def test_timestamp(state: State):
     s_in = """'Timestamp: {:%Y-%m-%d %H:%M:%S}'.format(datetime.datetime.now())"""
     s_expected = """f'Timestamp: {datetime.datetime.now():%Y-%m-%d %H:%M:%S}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_ifexpr():
+def test_ifexpr(state: State):
     s_in = """'%s' % (a if c else b)"""
     s_expected = """f'{a if c else b}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_binop():
+def test_binop(state: State):
     s_in = """'%s' % (a+b+c)"""
     s_expected = """f'{a + b + c}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_call():
+def test_call(state: State):
     s_in = """'%s' % fn(var)"""
     s_expected = """f'{fn(var)}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_string_specific_len(aggressive):
+def test_string_specific_len(state: State):
     s_in = """'%5s' % CLASS_NAMES[labels[j]]"""
     s_expected = """f'{CLASS_NAMES[labels[j]]:5}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    state.aggressive = True
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_dont_wrap_len(aggressive):
+def test_dont_wrap_len(state: State):
     s_in = """print('List length %d' % len(sys.argv))"""
     s_expected = """print(f'List length {len(sys.argv)}')"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    state.aggressive = True
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_string_in_string_single():
+def test_string_in_string_single(state: State):
     s_in = """print('getlivejpg: %s: %s' % (camera['name'], errmsg))"""
     s_expected = """print(f"getlivejpg: {camera['name']}: {errmsg}")"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_percent_tuple():
+def test_percent_tuple(state: State):
     s_in = """print("%s %s " % (var+var, abc))"""
     s_expected = """print(f"{var + var} {abc} ")"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_part_of_concat():
+def test_part_of_concat(state: State):
     s_in = """print('blah{}'.format(thing) + 'blah' + otherThing + "is %f" % x)"""
     s_expected = """print(f'blah{thing}' + 'blah' + otherThing + f"is {x:f}")"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_one_string():
+def test_one_string(state: State):
     s_in = """a = 'my string {}, but also {} and {}'.format(var, f, cada_bra)"""
     s_expected = """a = f'my string {var}, but also {f} and {cada_bra}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_nonatomic():
+def test_nonatomic(state: State):
     s_in = """'blah{0}'.format(thing - 1)"""
     s_expected = """f'blah{thing - 1}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_noqa():
+def test_noqa(state: State):
     s_in = """a = 'my string {}, but also {} and {}'.format(var, f, cada_bra)  # noqa: flynt"""
     s_expected = """a = 'my string {}, but also {} and {}'.format(var, f, cada_bra)  # noqa: flynt"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_noqa_other():
+def test_noqa_other(state: State):
     s_in = """a = '%s\\n' % var  # noqa: W731, flynt"""
     s_expected = """a = '%s\\n' % var  # noqa: W731, flynt"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_multiline():
+def test_multiline(state: State):
     s_in = """a = 'my string {}, but also {} and {}'.format(\nvar, \nf, \ncada_bra)"""
     s_expected = """a = f'my string {var}, but also {f} and {cada_bra}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_conversion():
+def test_conversion(state: State):
     s_in = """a = 'my string {}, but also {!r} and {!a}'.format(var, f, cada_bra)"""
     s_expected = """a = f'my string {var}, but also {f!r} and {cada_bra!a}'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_invalid_conversion():
+def test_invalid_conversion(state: State):
     s_in = """a = 'my string {}, but also {!b} and {!a}'.format(var, f, cada_bra)"""
     s_expected = s_in
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_invalid_conversion_names():
+def test_invalid_conversion_names(state: State):
     s_in = """a = 'my string {var}, but also {f!b}
      and {cada_bra!a}'.format(var, f, cada_bra)"""
     s_expected = s_in
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_dangerous_tuple():
+def test_dangerous_tuple(state: State):
     s_in = """print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))"""
     s_expected = s_in
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_percent_newline():
+def test_percent_newline(state: State):
     s_in = """a = '%s\\n' % var"""
     s_expected = """a = f'{var}\\n'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     print(s_out)
     print(s_expected)
     assert s_out == s_expected
 
 
-def test_format_newline():
+def test_format_newline(state: State):
     s_in = """a = '{}\\n'.format(var)"""
     s_expected = """a = f'{var}\\n'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
-def test_format_tab():
+def test_format_tab(state: State):
     s_in = """a = '{}\\t'.format(var)"""
     s_expected = """a = f'{var}\\t'"""
 
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
 
@@ -188,9 +185,9 @@ if var % 3 == 0:
     a = "my string {}".format(var)""".strip()
 
 
-def test_indented():
+def test_indented(state: State):
     s_expected = '''    a = f"my string {var}"'''
-    s_out, count = process.fstringify_code_by_line(indented)
+    s_out, count = process.fstringify_code_by_line(indented, state)
 
     assert count == 1
     assert s_out.split("\n")[2] == s_expected
@@ -208,17 +205,17 @@ a = f"foo {var.get('bar')}"
 """
 
 
-def test_line_split():
-    s_out, count = process.fstringify_code_by_line(split)
+def test_line_split(state: State):
+    s_out, count = process.fstringify_code_by_line(split, state)
 
     assert count == 1
     assert s_out == split_expected
 
 
-def test_line_split_single_line():
+def test_line_split_single_line(state: State):
     s_in = """a = 'foo {}'.format(var.get('bar'))"""
     expected = """a = f"foo {var.get('bar')}\""""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 1
     assert s_out == expected
@@ -236,61 +233,61 @@ a = f"foo {var.get('bar')}"
 """
 
 
-def test_line_split_kw():
-    s_out, count = process.fstringify_code_by_line(split_kw)
+def test_line_split_kw(state: State):
+    s_out, count = process.fstringify_code_by_line(split_kw, state)
 
     assert count == 1
     assert s_out == split_expected_kw
 
 
-def test_openpyxl():
+def test_openpyxl(state: State):
     s_in = """sheet['B{}'.format(i) : 'E{}'.format(i)]"""
     s_expected = """sheet[f'B{i}' : f'E{i}']"""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 2
     assert s_out == s_expected
 
 
-def test_double_percent_2():
+def test_double_percent_2(state: State):
     s_in = """print("p = %.3f%%" % (100 * p))"""
     s_expected = """print(f"p = {100 * p:.3f}%")"""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 1
     assert s_out == s_expected
 
 
-def test_str_in_str():
+def test_str_in_str(state: State):
     s_in = """a = "beautiful numbers to follow: {}".format(" ".join(lst))"""
     s_expected = """a = f"beautiful numbers to follow: {' '.join(lst)}\""""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 1
     assert s_out == s_expected
 
 
-def test_str_in_str_single_quote():
+def test_str_in_str_single_quote(state: State):
     s_in = """a = 'beautiful numbers to follow: {}'.format(" ".join(lst))"""
     s_expected = """a = f"beautiful numbers to follow: {' '.join(lst)}\""""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 1
     assert s_out == s_expected
 
 
-def test_chain_fmt():
+def test_chain_fmt(state: State):
     s_in = """a = "Hello {}".format(d["a{}".format(key)])"""
     s_expected = """a = f"Hello {d[f'a{key}']}\""""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 1
     assert s_out == s_expected
 
 
-def test_chain_fmt_3():
+def test_chain_fmt_3(state: State):
     s_in = """a = "Hello {}".format(d["a{}".format( d["a{}".format(key) ]) ] )"""
-    s_out, count = process.fstringify_code_by_line(s_in)
+    s_out, count = process.fstringify_code_by_line(s_in, state)
 
     assert count == 0
 
@@ -301,238 +298,243 @@ def write_row(self, xf, row, row_idx):
     attrs = {'r': '{}'.format(row_idx)}""".strip()
 
 
-def test_empty_line():
+def test_empty_line(state: State):
     s_expected = """    attrs = {'r': f'{row_idx}'}"""
-    s_out, count = process.fstringify_code_by_line(code_empty_line)
+    s_out, count = process.fstringify_code_by_line(code_empty_line, state)
 
     assert count == 1
     assert s_out.split("\n")[2] == s_expected
 
 
-def test_dict_perc():
+def test_dict_perc(state: State):
     s_in = "{'r': '%s' % row_idx}"
     s_expected = """{'r': f'{row_idx}'}"""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_legacy_unicode():
+def test_legacy_unicode(state: State):
     s_in = """u'%s, Cadabra' % datetime.now().year"""
     s_expected = """f'{datetime.now().year}, Cadabra'"""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_double_percent_no_prob():
+def test_double_percent_no_prob(state: State):
     s_in = "{'r': '%%%s%%' % row_idx}"
     s_expected = "{'r': f'%{row_idx}%'}"
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_percent_dict():
+def test_percent_dict(state: State):
     s_in = """a = '%(?)s world' % {'?': var}"""
     s_expected = """a = f'{var} world'"""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_percent_dict_fmt(aggressive):
+def test_percent_dict_fmt(state: State):
     s_in = """a = '%(?)ld world' % {'?': var}"""
     s_expected = """a = f'{int(var)} world'"""
+    state.aggressive = True
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
 
-
-def test_double_percent_dict():
+def test_double_percent_dict(state: State):
     s_in = """a = '%(?)s%%' % {'?': var}"""
     s_expected = """a = f'{var}%'"""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
 percent_dict_reused_key = """a = '%(?)s %(?)s' % {'?': var}"""
 
 
-def test_percent_dict_reused_key_noop():
+def test_percent_dict_reused_key_noop(state: State):
     assert (
-        process.fstringify_code_by_line(percent_dict_reused_key)[0]
+        process.fstringify_code_by_line(percent_dict_reused_key, state)[0]
         == percent_dict_reused_key
     )
 
 
-def test_percent_dict_reused_key_aggressive(aggressive):
+def test_percent_dict_reused_key_aggressive(state: State):
     s_expected = """a = f'{var} {var}'"""
 
-    assert process.fstringify_code_by_line(percent_dict_reused_key)[0] == s_expected
+    state.aggressive = True
+    assert (
+        process.fstringify_code_by_line(percent_dict_reused_key, state)[0] == s_expected
+    )
 
 
-def test_percent_dict_name():
+def test_percent_dict_name(state: State):
     s_in = """a = '%(?)s world' % var"""
     s_expected = """a = f"{var['?']} world\""""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_percent_dict_names():
+def test_percent_dict_names(state: State):
     s_in = """a = '%(?)s %(world)s' % var"""
     s_expected = """a = f"{var['?']} {var['world']}\""""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_percent_attr():
+def test_percent_attr(state: State):
     s_in = """src_info = 'application "%s"' % srcobj.import_name"""
     s_expected = """src_info = f'application "{srcobj.import_name}"'"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == s_expected
 
 
-def test_percent_dict_prefix():
+def test_percent_dict_prefix(state: State):
     s_in = """a = '%(?)s %(world).2f' % var"""
     s_expected = """a = f"{var['?']} {var['world']:.2f}\""""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_legacy_fmtspec(aggressive):
+def test_legacy_fmtspec(state: State):
     s_in = """d = '%i' % var"""
     s_expected = """d = f'{int(var)}'"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    state.aggressive = True
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == s_expected
 
 
-def test_str_in_str_curly():
+def test_str_in_str_curly(state: State):
     s_in = """desired_info += ["'clusters_options' items: {}. ".format({'random_option'})]"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert count == 0
 
 
-def test_str_in_str_methods():
+def test_str_in_str_methods(state: State):
     s_in = r"""string += '{} = {}\n'.format(('.').join(listKeys), json.JSONEncoder().encode(val))"""
     s_out = (
         """string += f"{'.'.join(listKeys)} = {json.JSONEncoder().encode(val)}\\n\""""
     )
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == s_out
     assert count > 0
 
 
-def test_decimal_precision():
+def test_decimal_precision(state: State):
     s_in = """e = '%.03f' % var"""
     s_expected = """e = f'{var:.03f}'"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == s_expected
 
 
-def test_width_spec(aggressive):
+def test_width_spec(state: State):
     s_in = "{'r': '%03f' % row_idx}"
     s_expected = """{'r': f'{row_idx:03f}'}"""
 
-    assert process.fstringify_code_by_line(s_in)[0] == s_expected
+    state.aggressive = True
+    assert process.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
-def test_equiv_expressions_repr():
+def test_equiv_expressions_repr(state: State):
     name = "bla"  # noqa: F841
 
     s_in = """'Setting %20r must be uppercase.' % name"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert eval(out) == eval(s_in)
 
 
-def test_equiv_expressions_hex():
+def test_equiv_expressions_hex(state: State):
     a = 17  # noqa: F841
 
     s_in = """'%.3x' % a"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert eval(out) == eval(s_in)
 
 
-def test_equiv_expressions_s():
+def test_equiv_expressions_s(state: State):
     name = "bla"  # noqa: F841
 
     s_in = """'Setting %20s must be uppercase.' % name"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert eval(out) == eval(s_in)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
-def test_concat():
+def test_concat(state: State):
     s_in = """msg = a + " World\""""
     s_expected = """msg = f"{a} World\""""
 
-    s_out, count = process.fstringify_concats(s_in)
+    s_out, count = process.fstringify_concats(s_in, state)
     assert s_out == s_expected
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
-def test_concat_two_sides():
+def test_concat_two_sides(state: State):
     s_in = """t = 'T is a string of value: ' + val + ' and thats great!'"""
     s_expected = """t = f"T is a string of value: {val} and thats great!\""""
 
-    s_out, count = process.fstringify_concats(s_in)
+    s_out, count = process.fstringify_concats(s_in, state)
     assert s_out == s_expected
 
 
 @pytest.mark.parametrize("fmt_spec", "egdixXu")
 @pytest.mark.parametrize("number", [0, 11, 0b111])
-def test_integers_equivalence(number, fmt_spec):
+def test_integers_equivalence(number, fmt_spec, state: State):
     percent_fmt_string = f"""'Setting %{fmt_spec} must be uppercase.' % number"""
-    out, count = process.fstringify_code_by_line(percent_fmt_string)
+    out, count = process.fstringify_code_by_line(percent_fmt_string, state)
 
     assert eval(out) == eval(percent_fmt_string)
 
 
 @pytest.mark.parametrize("fmt_spec", "egf")
 @pytest.mark.parametrize("number", [3.333_333_33, 15e-44, 3.142_854])
-def test_floats_equivalence(number, fmt_spec):
+def test_floats_equivalence(number, fmt_spec, state):
     percent_fmt_string = f"""'Setting %{fmt_spec} must be uppercase.' % number"""
-    out, count = process.fstringify_code_by_line(percent_fmt_string)
+    out, count = process.fstringify_code_by_line(percent_fmt_string, state)
 
     assert eval(out) == eval(percent_fmt_string)
 
 
 @pytest.mark.parametrize("fmt_spec", [".02f", ".01e", ".04g", "05f"])
 @pytest.mark.parametrize("number", [3.333_333_33, 15e-44, 3.142_854])
-def test_floats_precision_equiv(number, fmt_spec):
+def test_floats_precision_equiv(number, fmt_spec, state):
     percent_fmt_string = f"""'Setting %{fmt_spec} must be uppercase.' % number"""
-    out, count = process.fstringify_code_by_line(percent_fmt_string)
+    out, count = process.fstringify_code_by_line(percent_fmt_string, state)
 
     assert eval(out) == eval(percent_fmt_string)
 
 
-def test_multiline_tuple():
+def test_multiline_tuple(state: State):
     s_in = """s = '%s' % (
                     v['key'])"""
 
     expected = """s = f"{v['key']}\""""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == expected
 
 
-def test_kv_loop():
+def test_kv_loop(state: State):
     s_in = """', '.join('{}={}'.format(k, v) for k, v in d)"""
     expected = """', '.join(f'{k}={v}' for k, v in d)"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == expected
 
 
-def test_unknown_mod_percend_dictionary():
+def test_unknown_mod_percend_dictionary(state: State):
     """Unknown modifier must not result in partial conversion!"""
 
     s_in = """\"%(a)-6d %(a)s" % d"""
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert out == s_in
 
 
@@ -541,12 +543,12 @@ s_in_mixed_quotes = """'one is {} '
 """.strip()
 
 
-def test_mixed_quote_types():
+def test_mixed_quote_types(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""
 
     expected = '''f"one is {one} and two is {two}"'''
 
-    out, count = process.fstringify_code_by_line(s_in_mixed_quotes)
+    out, count = process.fstringify_code_by_line(s_in_mixed_quotes, state)
     assert out == expected
 
 
@@ -555,22 +557,22 @@ s_in_mixed_quotes_unsafe = """'one is "{}" '
 """.strip()
 
 
-def test_mixed_quote_types_unsafe():
+def test_mixed_quote_types_unsafe(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""
 
     # expected = '''f"one is {one} and two is {two}"'''
 
-    out, count = process.fstringify_code_by_line(s_in_mixed_quotes_unsafe)
+    out, count = process.fstringify_code_by_line(s_in_mixed_quotes_unsafe, state)
     assert out == s_in_mixed_quotes_unsafe
 
 
-def test_super_call():
+def test_super_call(state: State):
     """Regression for https://github.com/ikamensh/flynt/issues/103 -"""
 
     s_in = '"{}/{}".format(super(SuggestEndpoint, self).path, self.facet.suggest)'
     expected = 'f"{super(SuggestEndpoint, self).path}/{self.facet.suggest}"'
 
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert count == 1
     assert out == expected
 
@@ -585,10 +587,10 @@ var = f'bazfoo " {var} \\' bar'
 """
 
 
-def test_escaped_mix():
+def test_escaped_mix(state: State):
     """Regression for https://github.com/ikamensh/flynt/issues/114"""
 
-    out, count = process.fstringify_code_by_line(escaped)
+    out, count = process.fstringify_code_by_line(escaped, state)
     assert count == 1
     assert out == expected_escaped
 
@@ -603,10 +605,10 @@ var = f"bazfoo ' {var} \\" bar"
 """
 
 
-def test_escaped_mix_double():
+def test_escaped_mix_double(state: State):
     """Regression for https://github.com/ikamensh/flynt/issues/114"""
 
-    out, count = process.fstringify_code_by_line(escaped_2)
+    out, count = process.fstringify_code_by_line(escaped_2, state)
     assert count == 1
     assert out == expected_escaped_2
 
@@ -621,9 +623,9 @@ f'some {text} here as {placeholder}'
 """
 
 
-def test_112():
+def test_112(state: State):
     """Test for issue #112 on github"""
-    out, count = process.fstringify_code_by_line(issue_112)
+    out, count = process.fstringify_code_by_line(issue_112, state)
     assert count == 1
     assert out == expected_112
 
@@ -639,24 +641,25 @@ f'my string {my_var}'
 """
 
 
-def test_112_simple():
+def test_112_simple(state: State):
     """Test for issue #112 on github with a different input."""
-    out, count = process.fstringify_code_by_line(issue_112_simple)
+    out, count = process.fstringify_code_by_line(issue_112_simple, state)
     assert count == 1
     assert out == expected_112_simple
 
 
-def test_110(aggressive):
+def test_110(state: State):
     """Test for issue #110 on github"""
     s_in = "'{conn.login}:{conn.password}@'.format(conn=x)"
     expected_out = "f'{x.login}:{x.password}@'"
-    out, count = process.fstringify_code_by_line(s_in)
+    state.aggressive = True
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert count == 1
     assert out == expected_out
 
 
-def test_110_nonaggr():
+def test_110_nonaggr(state: State):
     """Test for issue #110 on github - no change in code expected outside of -aggr flag"""
     s_in = "'{conn.login}:{conn.password}@'.format(conn=x)"
-    out, count = process.fstringify_code_by_line(s_in)
+    out, count = process.fstringify_code_by_line(s_in, state)
     assert count == 0

--- a/test/test_static_join/test_sj_candidates.py
+++ b/test/test_static_join/test_sj_candidates.py
@@ -5,6 +5,7 @@ from typing import Tuple
 
 import pytest
 
+from flynt.state import State
 from flynt.static_join.candidates import JoinHound, join_candidates
 
 pytestmark = pytest.mark.skipif(
@@ -23,7 +24,7 @@ def code_and_ok() -> Tuple[str, int]:
 
 
 @pytest.mark.parametrize("method", ["hound", "api"])
-def test_find_victims(code_and_ok: Tuple[str, int], method: str):
+def test_find_victims(code_and_ok: Tuple[str, int], method: str, state: State):
     code, expected_ok = code_and_ok
     if method == "hound":
         tree = ast.parse(code)
@@ -31,7 +32,7 @@ def test_find_victims(code_and_ok: Tuple[str, int], method: str):
         ch.visit(tree)
         victims = ch.victims
     elif method == "api":
-        victims = list(join_candidates(code))
+        victims = list(join_candidates(code, state))
     else:
         raise NotImplementedError("...")
     assert len(victims) == expected_ok

--- a/test/test_str_concat/test_candidates.py
+++ b/test/test_str_concat/test_candidates.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+from flynt.state import State
 from flynt.string_concat.candidates import ConcatHound, concat_candidates
 
 
@@ -32,8 +33,8 @@ def test_find_victims_primitives(pycode_with_2_concats: str):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
-def test_find_victims_api(pycode_with_2_concats: str):
-    gen = concat_candidates(pycode_with_2_concats)
+def test_find_victims_api(pycode_with_2_concats: str, state: State):
+    gen = concat_candidates(pycode_with_2_concats, state)
     lst = list(gen)
 
     assert len(lst) == 2
@@ -44,9 +45,9 @@ def test_find_victims_api(pycode_with_2_concats: str):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
-def test_find_victims_parens():
+def test_find_victims_parens(state: State):
     txt_in = """print('blah' + (thing - 1))"""
-    gen = concat_candidates(txt_in)
+    gen = concat_candidates(txt_in, state)
     lst = list(gen)
 
     assert len(lst) == 1


### PR DESCRIPTION
This PR gets rid of modifying the state module wherever possible, in favor of a `State` dataclass. Wherever possible, I've tried to keep the low-level APIs state-less (pun intended), so should you need a single transform, you can do that without constructing a full State.

<del>Additionally,  it</del>A future PR gets rid of modifying `Chunk`s class-level state in favor of a `LexerContext` which is determined based on `state.multiline`.