### PR TITLE
tidied up some pylint and flake8 warnings

### DIFF
--- a/src/flynt/__main__.py
+++ b/src/flynt/__main__.py
@@ -1,4 +1,4 @@
-""" This file gets run when we call `python3 -m flynt` """
+"""This file gets run when we call `python3 -m flynt`."""
 
 import sys
 

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -96,13 +96,15 @@ def _fstringify_file(
     if not len(ast_before.body) == len(ast_after.body):
         log.error(
             f"Faulty result during conversion on {filename}: "
-            f"statement count has changed, which is not intended - skipping."
+            f"statement count has changed, which is not intended - skipping.",
         )
         return default_result()
 
     if state.dry_run:
         diff = unified_diff(
-            contents.split("\n"), new_code.split("\n"), fromfile=filename
+            contents.split("\n"),
+            new_code.split("\n"),
+            fromfile=filename,
         )
         print("\n".join(diff))
     else:
@@ -174,7 +176,7 @@ def _print_report(
         cc_reduction = total_cc_original - total_cc_new
         cc_percent_reduction = cc_reduction / total_cc_original
         print(
-            f"Character count reduction:                 {cc_reduction} ({cc_percent_reduction:.2%})\n"
+            f"Character count reduction:                 {cc_reduction} ({cc_percent_reduction:.2%})\n",
         )
 
         print("Per expression type:")
@@ -182,7 +184,7 @@ def _print_report(
             percent_fraction = state.percent_transforms / state.percent_candidates
             print(
                 f"Old style (`%`) expressions attempted:     {state.percent_transforms}/"
-                f"{state.percent_candidates} ({percent_fraction:.1%})"
+                f"{state.percent_candidates} ({percent_fraction:.1%})",
             )
         else:
             print("No old style (`%`) expressions attempted.")
@@ -190,7 +192,7 @@ def _print_report(
         if state.call_candidates:
             print(
                 f"`.format(...)` calls attempted:            {state.call_transforms}/"
-                f"{state.call_candidates} ({state.call_transforms / state.call_candidates:.1%})"
+                f"{state.call_candidates} ({state.call_transforms / state.call_candidates:.1%})",
             )
         else:
             print("No `.format(...)` calls attempted.")
@@ -198,7 +200,7 @@ def _print_report(
         if state.concat_candidates:
             print(
                 f"String concatenations attempted:           {state.concat_changes}/"
-                f"{state.concat_candidates} ({state.concat_changes / state.concat_candidates:.1%})"
+                f"{state.concat_candidates} ({state.concat_changes / state.concat_candidates:.1%})",
             )
         else:
             print("No concatenations attempted.")
@@ -206,7 +208,7 @@ def _print_report(
         if state.join_candidates:
             print(
                 f"Static string joins attempted:             {state.join_changes}/"
-                f"{state.join_candidates} ({state.join_changes / state.join_candidates:.1%})"
+                f"{state.join_candidates} ({state.join_changes / state.join_candidates:.1%})",
             )
         else:
             print("No static string joins attempted.")
@@ -215,7 +217,7 @@ def _print_report(
 
         if state.invalid_conversions:
             print(
-                f"Out of all attempted transforms, {state.invalid_conversions} resulted in errors."
+                f"Out of all attempted transforms, {state.invalid_conversions} resulted in errors.",
             )
             print("To find out specific error messages, use --verbose flag.")
 
@@ -230,7 +232,6 @@ def fstringify(
     excluded_files_or_paths: Optional[Collection[str]] = None,
 ) -> int:
     """determine if a directory or a single file was passed, and f-stringify it."""
-
     files = _resolve_files(files_or_paths, excluded_files_or_paths)
 
     status = fstringify_files(
@@ -240,15 +241,14 @@ def fstringify(
 
     if fail_on_changes:
         return status
-    else:
-        return 0
+    return 0
 
 
 def _resolve_files(
-    files_or_paths: List[str], excluded_files_or_paths: Optional[Collection[str]]
+    files_or_paths: List[str],
+    excluded_files_or_paths: Optional[Collection[str]],
 ) -> List[str]:
     """Resolve relative paths and directory names into a list of absolute paths to python files."""
-
     files = []
     _blacklist = blacklist.copy()
     if excluded_files_or_paths is not None:
@@ -274,7 +274,6 @@ def _resolve_files(
 
 def encoding_by_bom(path: str, default: str = "utf-8") -> Tuple[str, Optional[bytes]]:
     """Adapted from https://stackoverflow.com/questions/13590749/reading-unicode-file-data-with-bom-chars-in-python/24370596#24370596"""
-
     with open(path, "rb") as f:
         raw = f.read(4)  # will read less if the file is smaller
     # BOM_UTF32_LE's start is equal to BOM_UTF16_LE so need to try the former first

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -137,7 +137,10 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
     )
 
     parser.add_argument(
-        "src", action="store", nargs="*", help="source file(s) or directory"
+        "src",
+        action="store",
+        nargs="*",
+        help="source file(s) or directory",
     )
 
     parser.add_argument(
@@ -151,7 +154,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
     if args.version:
         print(__version__)
         return 0
-    elif not args.src:
+    if not args.src:
         print("flynt: error: the following arguments are required: src")
         parser.print_usage()
         return 1
@@ -159,13 +162,13 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
     if args.transform_concats and sys.version_info < (3, 8):
         raise Exception(
             f"""Transforming string concatenations is only possible with flynt
-                installed to a python3.8+ interpreter. Currently using {sys.version_info}."""
+                installed to a python3.8+ interpreter. Currently using {sys.version_info}.""",
         )
 
     if args.transform_joins and sys.version_info < (3, 8):
         raise Exception(
             f"""Transforming joins is only possible with flynt
-                installed to a python3.8+ interpreter. Currently using {sys.version_info}."""
+                installed to a python3.8+ interpreter. Currently using {sys.version_info}.""",
         )
 
     logging.basicConfig(
@@ -201,7 +204,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
             warnings.warn(
                 f"Unknown config options: {redundant}. "
                 f"This might be a spelling problem. "
-                f"Supported options are: {supported_args}"
+                f"Supported options are: {supported_args}",
             )
         parser.set_defaults(**cfg)
         args = parser.parse_args(arglist)

--- a/src/flynt/lexer/Chunk.py
+++ b/src/flynt/lexer/Chunk.py
@@ -206,5 +206,4 @@ class Chunk:
     def __repr__(self):
         if self.tokens:
             return f"Chunk: {self}"
-        else:
-            return "Empty Chunk"
+        return "Empty Chunk"

--- a/src/flynt/process.py
+++ b/src/flynt/process.py
@@ -62,7 +62,7 @@ class JoinTransformer:
         start_line, start_idx, _ = (chunk.start_line, chunk.start_idx, chunk.end_idx)
         if start_line == self.last_line:
             self.results.append(
-                self.src_lines[self.last_line][self.last_idx : start_idx]
+                self.src_lines[self.last_line][self.last_idx : start_idx],
             )
         else:
             self.results.append(self.src_lines[self.last_line][self.last_idx :] + "\n")
@@ -145,7 +145,8 @@ class JoinTransformer:
         # remove redundant parenthesis
         if len(self.results) < 2 or not self.results[-2]:
             return
-        elif len(self.src_lines[self.last_line]) == self.last_idx:
+
+        if len(self.src_lines[self.last_line]) == self.last_idx:
             return
 
         if (
@@ -155,10 +156,9 @@ class JoinTransformer:
             for char in reversed(self.results[-2][:-1]):
                 if char in string.whitespace:
                     continue
-                elif char in "(=[+*":
+                if char in "(=[+*":
                     break
-                else:
-                    return
+                return
 
             self.results[-2] = self.results[-2][:-1]
             self.last_idx += 1
@@ -175,7 +175,10 @@ class JoinTransformer:
 def fstringify_code_by_line(code: str, state: State) -> Tuple[str, int]:
     """returns fstringified version of the code and amount of lines edited."""
     return _transform_code(
-        code, split.get_fstringify_chunks, partial(transform_chunk, state=state), state
+        code,
+        split.get_fstringify_chunks,
+        partial(transform_chunk, state=state),
+        state,
     )
 
 
@@ -206,7 +209,6 @@ def _transform_code(
     state: State,
 ) -> Tuple[str, int]:
     """returns fstringified version of the code and amount of lines edited."""
-
     len_limit = _multiline_settings(state)
     jt = JoinTransformer(code, len_limit, candidates_iter_factory, transform_func)
     return jt.fstringify_code_by_line()

--- a/src/flynt/pyproject_finder.py
+++ b/src/flynt/pyproject_finder.py
@@ -52,7 +52,7 @@ def find_project_root(srcs: Sequence[str]) -> Path:
 
 
 def find_pyproject_toml(path_search_start: Tuple[str, ...]) -> Optional[str]:
-    """Find the absolute filepath to a pyproject.toml if it exists"""
+    """Find the absolute filepath to a pyproject.toml if it exists."""
     path_project_root = find_project_root(path_search_start)
     path_pyproject_toml = path_project_root / "pyproject.toml"
     if path_pyproject_toml.is_file():
@@ -72,7 +72,7 @@ def find_pyproject_toml(path_search_start: Tuple[str, ...]) -> Optional[str]:
 
 
 def parse_pyproject_toml(path_config: str) -> Dict[str, Any]:
-    """Parse a pyproject toml file, pulling out relevant parts for flynt
+    """Parse a pyproject toml file, pulling out relevant parts for flynt.
 
     If parsing fails, will raise a tomli.TOMLDecodeError
     """

--- a/src/flynt/static_join/transformer.py
+++ b/src/flynt/static_join/transformer.py
@@ -34,7 +34,7 @@ class JoinTransformer(ast.NodeTransformer):
                     arg.s
                     for arg in args_with_interleaved_joiner
                     if isinstance(arg, ast.Str)
-                )
+                ),
             )
         return ast.JoinedStr(args_with_interleaved_joiner)
 

--- a/src/flynt/string_concat/candidates.py
+++ b/src/flynt/string_concat/candidates.py
@@ -7,7 +7,7 @@ from flynt.utils import is_str_literal
 
 
 def is_string_concat(node: ast.AST) -> bool:
-    """Returns True for nodes representing a string concatenation"""
+    """Returns True for nodes representing a string concatenation."""
     if is_str_literal(node):
         return True
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
@@ -22,7 +22,7 @@ class ConcatHound(ast.NodeVisitor):
 
     def visit_BinOp(self, node: ast.BinOp) -> None:
         """
-        Finds all nodes that are string concatenations with a literal
+        Finds all nodes that are string concatenations with a literal.
         """
         if is_string_concat(node):
             self.victims.append(AstChunk(node))

--- a/src/flynt/string_concat/string_in_string.py
+++ b/src/flynt/string_concat/string_in_string.py
@@ -13,7 +13,7 @@ class SinSDetector(ast.NodeVisitor):
         self.sns_depth += 1
         if self.sns_depth > self.maxdepth:
             raise StringEmbeddingTooDeep(
-                f"String embedding too deep: {self.sns_depth} > {self.maxdepth}"
+                f"String embedding too deep: {self.sns_depth} > {self.maxdepth}",
             )
 
         self.generic_visit(node)

--- a/src/flynt/transform/FstringifyTransformer.py
+++ b/src/flynt/transform/FstringifyTransformer.py
@@ -19,9 +19,8 @@ class FstringifyTransformer(ast.NodeTransformer):
 
     def visit_Call(self, node: ast.Call) -> ast.AST:
         """
-        Convert `ast.Call` to `ast.JoinedStr` f-string
+        Convert `ast.Call` to `ast.JoinedStr` f-string.
         """
-
         if self.state.transform_format and matching_call(node):
             self.state.call_candidates += 1
 
@@ -30,7 +29,8 @@ class FstringifyTransformer(ast.NodeTransformer):
                 return node
 
             result_node, str_in_str = joined_string(
-                node, aggressive=self.state.aggressive
+                node,
+                aggressive=self.state.aggressive,
             )
             self.string_in_string = str_in_str
             self.visit(result_node)
@@ -41,7 +41,7 @@ class FstringifyTransformer(ast.NodeTransformer):
         return node
 
     def visit_BinOp(self, node: ast.BinOp) -> ast.AST:
-        """Convert `ast.BinOp` to `ast.JoinedStr` f-string
+        """Convert `ast.BinOp` to `ast.JoinedStr` f-string.
 
         Currently only if a string literal `ast.Str` is on the left side of the `%`
         and one of `ast.Tuple`, `ast.Name`, `ast.Dict` is on the right
@@ -51,7 +51,6 @@ class FstringifyTransformer(ast.NodeTransformer):
 
         Returns ast.JoinedStr (f-string)
         """
-
         if self.state.transform_percent and is_percent_stringify(node):
             # Mypy doesn't understand the is_percent_stringify acts
             # as a type guard, so we need the assert here.
@@ -72,7 +71,8 @@ class FstringifyTransformer(ast.NodeTransformer):
                     return node
 
             result_node, str_in_str = transform_binop(
-                node, aggressive=self.state.aggressive
+                node,
+                aggressive=self.state.aggressive,
             )
             self.string_in_string = str_in_str
             self.counter += 1

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -32,7 +32,8 @@ def joined_string(
 ) -> Tuple[Union[ast.JoinedStr, ast.Str], bool]:
     """Transform a "...".format() call node into a f-string node."""
     assert isinstance(fmt_call.func, ast.Attribute) and isinstance(
-        fmt_call.func.value, ast.Str
+        fmt_call.func.value,
+        ast.Str,
     )
     string = fmt_call.func.value.s
     var_map: Dict[Any, Any] = {kw.arg: kw.value for kw in fmt_call.keywords}
@@ -63,7 +64,7 @@ def joined_string(
 
         if "[" in var_name:
             raise FlyntException(
-                f"Skipping f-stringify of a fmt call with indexed name {var_name}"
+                f"Skipping f-stringify of a fmt call with indexed name {var_name}",
             )
 
         suffix = ""
@@ -90,7 +91,7 @@ def joined_string(
                 ast_name = var_map.pop(identifier)
             except KeyError as e:
                 raise ConversionRefused(
-                    f"A variable {identifier} is used multiple times - better not to replace it."
+                    f"A variable {identifier} is used multiple times - better not to replace it.",
                 ) from e
 
         if suffix:
@@ -99,20 +100,18 @@ def joined_string(
 
     if var_map and not aggressive:
         raise FlyntException(
-            f"Some variables were never used: {var_map} - skipping conversion, it's a risk of bug."
+            f"Some variables were never used: {var_map} - skipping conversion, it's a risk of bug.",
         )
 
     def is_literal_string(node):
         if sys.version_info < (3, 8):
             return isinstance(node, ast.Str)
-        else:
-            return isinstance(node, ast.Constant) and isinstance(node.value, str)
+        return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
     def literal_string_value(node):
         if sys.version_info < (3, 8):
             return node.s
-        else:
-            return node.value
+        return node.value
 
     def fix_literals(segment):
         if (

--- a/src/flynt/transform/transform.py
+++ b/src/flynt/transform/transform.py
@@ -18,7 +18,6 @@ def transform_chunk(
     quote_type: str = QuoteTypes.triple_double,
 ) -> Tuple[str, bool]:
     """Convert a block of code to an f-string
-
     Args:
         state: State object, for settings and statistics
         code: The code to convert.
@@ -27,7 +26,6 @@ def transform_chunk(
     Returns:
        Tuple: resulting code, boolean: was it changed?
     """
-
     try:
         tree = ast.parse(code)
         converted, changed, str_in_str = fstringify_node(

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -45,7 +45,7 @@ def ast_formatted_value(
 
     if ast_to_string(val).startswith("{"):
         raise ConversionRefused(
-            "values starting with '{' are better left not transformed."
+            "values starting with '{' are better left not transformed.",
         )
 
     if fmt_str:

--- a/test/test_str_concat/test_transformer.py
+++ b/test/test_str_concat/test_transformer.py
@@ -162,7 +162,7 @@ def test_backslash():
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
 def test_parens():
-    txt = """(blah1 
+    txt = """(blah1
         + 'b')"""
 
     expected = '''f"{blah1}b"'''

--- a/update_readme.py
+++ b/update_readme.py
@@ -32,7 +32,7 @@ def main():
     # disable argparse exiting the entire program when it prints help,
     # and patch the terminal size so we get the same output all the time
     with contextlib.redirect_stdout(sio), contextlib.suppress(
-        SystemExit
+        SystemExit,
     ), patch_terminal_size():
         sys.argv = ["flynt", "--help"]
         run_flynt_cli()


### PR DESCRIPTION
 - sorted imports
 - cleaned some whitespace
 - tidied some flake8 docstring warnings
 - fixed trailing commas as per flake8 for 3.5,3.6+
 - added specific encoding for file writing
 - simplified some conditional statements
