### PR TITLE
Fix state reading from args, support state with `--string`

### DIFF
--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -7,7 +7,7 @@ import warnings
 from typing import List, Optional
 
 from flynt import __version__
-from flynt.api import fstringify, fstringify_code_by_line, fstringify_content
+from flynt.api import fstringify, fstringify_content
 from flynt.pyproject_finder import find_pyproject_toml, parse_pyproject_toml
 from flynt.state import State
 
@@ -184,11 +184,12 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         logging.getLogger("flynt").setLevel(logging.DEBUG)
 
     if args.string:
-        converted, _ = fstringify_code_by_line(
-            " ".join(args.src),
-            state=state,
+        content = " ".join(args.src)
+        result = fstringify_content(
+            content,
+            state,
         )
-        print(converted)
+        print(result.content if result else content)
         return 0
     if "-" in args.src:
         if len(args.src) > 1:

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -179,11 +179,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         level=(logging.DEBUG if args.verbose else logging.CRITICAL),
     )
 
-    state = State(
-        aggressive=args.aggressive,
-        quiet=args.quiet,
-        dry_run=args.dry_run,
-    )
+    state = state_from_args(args)
     if args.verbose:
         logging.getLogger("flynt").setLevel(logging.DEBUG)
 
@@ -222,6 +218,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
             )
         parser.set_defaults(**cfg)
         args = parser.parse_args(arglist)
+        state = state_from_args(args)
     if not args.quiet:
         print(salutation)
     if args.verbose:
@@ -233,4 +230,18 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         excluded_files_or_paths=args.exclude,
         fail_on_changes=args.fail_on_change,
         state=state,
+    )
+
+
+def state_from_args(args) -> State:
+    return State(
+        aggressive=args.aggressive,
+        dry_run=args.dry_run,
+        len_limit=args.line_length,
+        multiline=(not args.no_multiline),
+        quiet=args.quiet,
+        transform_concat=args.transform_concats,
+        transform_format=args.transform_format,
+        transform_join=args.transform_joins,
+        transform_percent=args.transform_percent,
     )

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 
 import pytest
 
@@ -81,6 +82,26 @@ def test_cli_string_unquoted(capsys, code_in, code_out):
 
     out, err = capsys.readouterr()
     assert out.strip() == code_out
+    assert err == ""
+
+
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+def test_cli_string_supports_flags(capsys):
+    """
+    Tests a --string invocation also does additional transformations.
+
+    See https://github.com/ikamensh/flynt/issues/162
+    """
+    return_code = run_flynt_cli(
+        [
+            "-tc",
+            "--string",
+            "test_string = 'This' + ' ' + 'may' + ' ' + 'not' + ' ' + 'work'",
+        ]
+    )
+    assert return_code == 0
+    out, err = capsys.readouterr()
+    assert out.strip() == 'test_string = f"This may not work"'
     assert err == ""
 
 


### PR DESCRIPTION
Turns out #155 had a bug that prevented `-tc`, etc. to be propagated to the `State`. My bad...!

This also fixes #162 on the way.