### PR TITLE
add a --stdout option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
           - --remove-all-unused-imports
         exclude: test/integration/(actual|expected|samples).*
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,8 +39,6 @@ repos:
     rev: 5.0.4
     hooks:
       - id: flake8  # See setup.cfg for args
-        additional_dependencies:
-          - flake8-black
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
     hooks:

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -53,20 +53,24 @@ def _fstringify_file(
         filename=filename,
     )
 
-    if result and result.n_changes:  # success?
-        new_code = result.content
-        if state.dry_run:
-            diff = unified_diff(
-                contents.split("\n"),
-                new_code.split("\n"),
-                fromfile=filename,
-            )
-            print("\n".join(diff))
-        else:
-            with open(filename, "wb") as outf:
-                if bom is not None:
-                    outf.write(bom)
-                outf.write(new_code.encode(encoding))
+    if result is None:
+        return None
+
+    new_code = result.content
+    if state.dry_run and result.n_changes:
+        diff = unified_diff(
+            contents.split("\n"),
+            new_code.split("\n"),
+            fromfile=filename,
+        )
+        print("\n".join(diff))
+    elif state.stdout:
+        print(new_code)
+    elif result.n_changes:
+        with open(filename, "wb") as outf:
+            if bom is not None:
+                outf.write(bom)
+            outf.write(new_code.encode(encoding))
     return result
 
 

--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -12,6 +12,7 @@ class State:
     quiet: bool = False
     aggressive: bool = False
     dry_run: bool = False
+    stdout: bool = False
     multiline: bool = True
     len_limit: Optional[int] = None
     transform_percent: bool = True

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -153,3 +153,35 @@ def test_cli_dry_run(capsys, sample_file):
 
     assert out.strip().endswith(farewell_message.strip())
     assert err == ""
+
+
+@pytest.mark.parametrize(
+    "sample_file",
+    ["all_named.py", "first_string.py", "percent_dict.py", "multiline_limit.py"],
+)
+def test_cli_stdout(capsys, sample_file):
+    """
+    Tests the --stdout option with a few files
+    """
+    # Get input/output paths and read them
+    folder = os.path.dirname(__file__)
+    source_path = os.path.join(folder, "samples_in", sample_file)
+    expected_path = os.path.join(folder, "expected_out", sample_file)
+    with open(expected_path) as file:
+        # file.readlines() returns lines with "\n" endings, which we must strip
+        # away for comparing with out.splitlines() which removes line endings.
+        expected_lines = [line.rstrip() for line in file.readlines()]
+
+    # Run the CLI
+    return_code = run_flynt_cli(["--stdout", source_path])
+    assert return_code == 0
+
+    # Check that the output includes the output code, and no farewell message
+    out, err = capsys.readouterr()
+    actual_lines = out.rstrip().splitlines()
+    for line in expected_lines:
+        assert line in actual_lines
+    for line in actual_lines:
+        assert line in expected_lines
+    assert not out.strip().endswith(farewell_message.strip())
+    assert err == ""


### PR DESCRIPTION
Print the output to stdout instead of writing it in place to the file. This is similar to --dry-run, but it does not print a diff, it prints the modified (or possibly unchanged) code.

Related to #160 