### PR TITLE
pre-commit: Replace bandit with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,13 +55,32 @@ include = [
     "/src",
 ]
 
-[tool.bandit]
-exclude_dirs = ["test"]
-skips = ["B101"]
-
 [tool.mypy]
 exclude = "test/integration/(actual|expected|samples).*"
 
 [[tool.mypy.overrides]]
 module = "astor"
 ignore_missing_imports = true
+
+[tool.ruff]
+extend-select = [
+    "C9",
+    "PLR091",
+    "S",
+]
+extend-ignore = [
+    "S101",
+]
+line-length = 141
+target-version = py37
+
+[tool.ruff.mccabe]
+max-complexity = 22
+
+[tool.ruff.pylint]
+max-args = 7
+max-branches = 18
+max-statements = 67
+
+[tool.ruff.per-file-ignores]
+"test/integration/*" = F821  # Undefined names


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins, and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)