### PR TITLE
Apply more ruff rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,14 +63,34 @@ module = "astor"
 ignore_missing_imports = true
 
 [tool.ruff]
-extend-select = [
-    "C9",
-    "I",
-    "PLR091",
-    "S",
+select = [
+    "C4",   # flake8-comprehensions
+    "C90",  # mccabe
+    "E",    # pycodestyle
+    "F",    # Pyflakes
+    "I",    # isort
+    "ICN",  # flake8-import-conventions
+    "PIE",  # flake8-pie
+    "PL",   # Pylint
+    "PYI",  # flake8-pyi
+    "RET",  # flake8-return
+    "RSE",  # flake8-raise
+    "RUF",  # Ruff-specific rules
+    "S",    # flake8-bandit
+    "SIM",  # flake8-simplify
+    "SLF",  # flake8-self
+    "T10",  # flake8-debugger
+    "TCH",  # flake8-type-checking
+    "TID",  # flake8-tidy-imports
+    "UP",   # pyupgrade
+    "W",    # pycodestyle
+    "YTT",  # flake8-2020
 ]
-extend-ignore = [
+ignore = [
+    "PLC1901",
+    "PLR2004",
     "S101",
+    "UP03",
 ]
 line-length = 141
 target-version = "py37"
@@ -90,6 +110,9 @@ max-statements = 67
     "F821",
     "F841",
     "I",
+    "RET503",
+    "UP",
+    "W292",
  ]
 "test/test_lexer.py" = ["F841"]
 "test/test_pyproject.py" = ["E712"]

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -135,7 +135,7 @@ def fstringify_content(
         )
         return None
 
-    if not len(ast_before.body) == len(ast_after.body):
+    if len(ast_before.body) != len(ast_after.body):
         log.error(
             f"Faulty result during conversion on {filename}: "
             f"statement count has changed, which is not intended - skipping.",
@@ -264,9 +264,7 @@ def fstringify(
         state=state,
     )
 
-    if fail_on_changes:
-        return status
-    return 0
+    return status if fail_on_changes else 0
 
 
 def _resolve_files(

--- a/src/flynt/lexer/Chunk.py
+++ b/src/flynt/lexer/Chunk.py
@@ -62,21 +62,20 @@ class Chunk:
             else:
                 self.percent_ongoing = True
 
+        elif self.percent_ongoing:
+            self.tokens.append(t)
+            if t.is_string() and "{" not in str(self):
+                self.string_in_string = True
+            if self.is_parseable:
+                self.percent_ongoing = False
+                self.successful = True
+        elif t.is_expr_continuation_op():
+            self.tokens.append(t)
+            self.percent_ongoing = True
         else:
-            if self.percent_ongoing:
-                self.tokens.append(t)
-                if t.is_string() and "{" not in str(self):
-                    self.string_in_string = True
-                if self.is_parseable:
-                    self.percent_ongoing = False
-                    self.successful = True
-            elif t.is_expr_continuation_op():
-                self.tokens.append(t)
-                self.percent_ongoing = True
-            else:
-                self.complete = True
-                self.successful = self.is_parseable
-                return REUSE
+            self.complete = True
+            self.successful = self.is_parseable
+            return REUSE
         return None
 
     def call_append(self, t: PyToken) -> None:

--- a/src/flynt/lexer/split.py
+++ b/src/flynt/lexer/split.py
@@ -57,6 +57,5 @@ def get_fstringify_chunks(
 
         if len(chunk) and chunk[-1].is_string():
             last_concat = True
-        else:
-            if lexer_context.multiline or len(chunk) > 0:
-                last_concat = False
+        elif lexer_context.multiline or len(chunk) > 0:
+            last_concat = False

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -70,7 +70,7 @@ def joined_string(
         suffix = ""
         if "." in var_name:
             idx = var_name.find(".")
-            var_name, suffix = var_name[:idx], var_name[idx + 1 :]
+            var_name, suffix = var_name[:idx], var_name[idx + 1 :]  # noqa: PLW2901
 
         identifier: Union[str, int]
         if var_name.isdigit():

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -30,7 +30,7 @@ def is_percent_stringify(node: ast.BinOp) -> bool:
     return (
         isinstance(node.left, ast.Str)
         and isinstance(node.op, ast.Mod)
-        and isinstance(node.right, tuple([ast.Tuple, ast.Dict, *supported_operands]))
+        and isinstance(node.right, (ast.Tuple, ast.Dict, *supported_operands))
     )
 
 

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -48,10 +48,7 @@ def ast_formatted_value(
             "values starting with '{' are better left not transformed.",
         )
 
-    if fmt_str:
-        format_spec = ast.JoinedStr([ast_string_node(fmt_str)])
-    else:
-        format_spec = None
+    format_spec = ast.JoinedStr([ast_string_node(fmt_str)]) if fmt_str else None
 
     conversion_val = -1 if conversion is None else ord(conversion.replace("!", ""))
     return ast.FormattedValue(
@@ -69,9 +66,10 @@ def fixup_transformed(tree: ast.AST, quote_type: Optional[str] = None) -> str:
     il = FstrInliner()
     il.visit(tree)
     new_code = ast_to_string(tree)
-    if quote_type is None:
-        if new_code[:4] == 'f"""' or new_code[:3] == "'''" or new_code[:3] == '"""':
-            quote_type = QuoteTypes.double
+    if quote_type is None and (
+        new_code[:4] == 'f"""' or new_code[:3] in ("'''", '"""')
+    ):
+        quote_type = QuoteTypes.double
     if quote_type is not None:
         new_code = set_quote_type(new_code, quote_type)
     new_code = new_code.replace("\n", "\\n")

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -97,7 +97,7 @@ def test_indented():
 def test_empty_line():
     code_empty_line = """
     def write_row(self, xf, row, row_idx):
-    
+
         attrs = {'r': '{}'.format(row_idx)}""".strip()
 
     generator = split.get_fstringify_chunks(code_empty_line)

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -539,7 +539,7 @@ def test_unknown_mod_percend_dictionary(state: State):
 
 
 s_in_mixed_quotes = """'one is {} '
-"and two is {}".format(one, two) 
+"and two is {}".format(one, two)
 """.strip()
 
 
@@ -553,7 +553,7 @@ def test_mixed_quote_types(state: State):
 
 
 s_in_mixed_quotes_unsafe = """'one is "{}" '
-"and two is {}".format('"'.join(one), two) 
+"and two is {}".format('"'.join(one), two)
 """.strip()
 
 


### PR DESCRIPTION
# https://beta.ruff.rs/docs/rules
```
select = [
    "C4",   # flake8-comprehensions
    "C90",  # mccabe
    "E",    # pycodestyle
    "F",    # Pyflakes
    "I",    # isort
    "ICN",  # flake8-import-conventions
    "PIE",  # flake8-pie
    "PL",   # Pylint
    "PYI",  # flake8-pyi
    "RET",  # flake8-return
    "RSE",  # flake8-raise
    "RUF",  # Ruff-specific rules
    "S",    # flake8-bandit
    "SIM",  # flake8-simplify
    "SLF",  # flake8-self
    "T10",  # flake8-debugger
    "TCH",  # flake8-type-checking
    "TID",  # flake8-tidy-imports
    "UP",   # pyupgrade
    "W",    # pycodestyle
    "YTT",  # flake8-2020
]
```