### PR TITLE
Set line-limit argument type to int

### DIFF
--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -56,6 +56,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         "the resulting single line will fit into the line length limit. "
         "Default value is 88 characters.",
         default=88,
+        type=int,
     )
 
     group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
Manually set the line limit argument to int type. Was getting 

```
File ".../process.py", line 130, in maybe_replace
    len(f"{converted}{rest}") <= self.len_limit - chunk.start_idx
TypeError: unsupported operand type(s) for -: 'str' and 'int'
```

Without this fix the line limit was being passed in as a string.