### PR TITLE
Use ast to find candidate fstring expressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #### v.1.0.0
 
+Drop support for python 3.7.
+
 ##### Moved % and .format expression identification to `ast` instead of legacy token state machine. 
 This has led to small changes in formatting of output code, e.g. type of quotes in ambiguous cases 
 might have changed. Example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+#### v.1.0.0
+
+##### Moved % and .format expression identification to `ast` instead of legacy token state machine. 
+This has led to small changes in formatting of output code, e.g. type of quotes in ambiguous cases 
+might have changed. Example:
+`'first part {}'"second part {}".format(one, two)` used to result in `"` quotes, 
+and now results in `'`, as in `f'first part {one}second part {two}'`. I think it's a minor change
+in the output. At the same time it's a huge simplification of the source code that should help 
+maintain and develop this project in the future.
+
+
 #### v.0.77
 
 *[Contributed by Aarni Koskela]* `--transform-joins` (`-tj`) will transform string join operations on static operands

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ keywords = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/flynt/__init__.py
+++ b/src/flynt/__init__.py
@@ -2,7 +2,7 @@
 from old "%-formatted" and .format(...) strings into Python 3.6+'s f-strings.
 Learn more about f-strings at https://www.python.org/dev/peps/pep-0498/"""
 
-__version__ = "0.78"
+__version__ = "1.0.0"
 
 from flynt.cli import main
 

--- a/src/flynt/candidates/ast_call_candidates.py
+++ b/src/flynt/candidates/ast_call_candidates.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from .ast_chunk import AstChunk
+from flynt.state import State
+
+
+import ast
+
+
+def is_call_format(node):
+    return all(
+        [
+            isinstance(node, ast.Call),
+            isinstance(node.func, ast.Attribute),
+            isinstance(node.func.value, ast.Str),
+            node.func.attr == "format",
+        ]
+    )
+
+
+class CallFmtFinder(ast.NodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.candidates: List[AstChunk] = []
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """
+        Finds all nodes that are string concatenations with a literal.
+        """
+        if is_call_format(node):
+            self.candidates.append(AstChunk(node))
+        else:
+            self.generic_visit(node)
+
+
+def call_candidates(code: str, state: State) -> List[AstChunk]:
+    tree = ast.parse(code)
+
+    finder = CallFmtFinder()
+    finder.visit(tree)
+
+    state.call_candidates += len(finder.candidates)
+    return finder.candidates

--- a/src/flynt/candidates/ast_call_candidates.py
+++ b/src/flynt/candidates/ast_call_candidates.py
@@ -8,13 +8,11 @@ import ast
 
 
 def is_call_format(node):
-    return all(
-        [
-            isinstance(node, ast.Call),
-            isinstance(node.func, ast.Attribute),
-            isinstance(node.func.value, ast.Str),
-            node.func.attr == "format",
-        ]
+    return (
+        isinstance(node, ast.Call) and
+        isinstance(node.func, ast.Attribute) and
+        node.func.attr == "format" and
+        isinstance(node.func.value, (ast.Str, ast.Name))
     )
 
 

--- a/src/flynt/candidates/ast_call_candidates.py
+++ b/src/flynt/candidates/ast_call_candidates.py
@@ -1,10 +1,9 @@
+import ast
 from typing import List
 
-from .ast_chunk import AstChunk
 from flynt.state import State
 
-
-import ast
+from .ast_chunk import AstChunk
 
 
 def is_call_format(node):

--- a/src/flynt/candidates/ast_call_candidates.py
+++ b/src/flynt/candidates/ast_call_candidates.py
@@ -8,10 +8,10 @@ from .ast_chunk import AstChunk
 
 def is_call_format(node):
     return (
-        isinstance(node, ast.Call) and
-        isinstance(node.func, ast.Attribute) and
-        node.func.attr == "format" and
-        isinstance(node.func.value, (ast.Str, ast.Name))
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "format"
+        and isinstance(node.func.value, (ast.Str, ast.Name))
     )
 
 

--- a/src/flynt/candidates/ast_chunk.py
+++ b/src/flynt/candidates/ast_chunk.py
@@ -2,8 +2,6 @@
 
 import ast
 
-from flynt.format import QuoteTypes
-
 
 class AstChunk:
     def __init__(self, node: ast.AST) -> None:
@@ -39,7 +37,7 @@ class AstChunk:
 
     @property
     def quote_type(self) -> str:
-        return QuoteTypes.double
+        raise NotImplementedError
 
     def __str__(self) -> str:
         from flynt.utils import ast_to_string

--- a/src/flynt/candidates/ast_percent_candidates.py
+++ b/src/flynt/candidates/ast_percent_candidates.py
@@ -8,9 +8,9 @@ from .ast_chunk import AstChunk
 
 def is_percent_format(node):
     return (
-        isinstance(node, ast.BinOp) and
-        isinstance(node.op, ast.Mod) and
-        isinstance(node.left, ast.Str)
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Mod)
+        and isinstance(node.left, ast.Str)
     )
 
 

--- a/src/flynt/candidates/ast_percent_candidates.py
+++ b/src/flynt/candidates/ast_percent_candidates.py
@@ -8,12 +8,10 @@ import ast
 
 
 def is_percent_format(node):
-    return all(
-        [
-            isinstance(node, ast.BinOp),
-            isinstance(node.op, ast.Mod),
-            isinstance(node.left, ast.Str),
-        ]
+    return (
+        isinstance(node, ast.BinOp) and
+        isinstance(node.op, ast.Mod) and
+        isinstance(node.left, ast.Str)
     )
 
 

--- a/src/flynt/candidates/ast_percent_candidates.py
+++ b/src/flynt/candidates/ast_percent_candidates.py
@@ -1,10 +1,9 @@
+import ast
 from typing import List
 
-from .ast_chunk import AstChunk
 from flynt.state import State
 
-
-import ast
+from .ast_chunk import AstChunk
 
 
 def is_percent_format(node):

--- a/src/flynt/candidates/ast_percent_candidates.py
+++ b/src/flynt/candidates/ast_percent_candidates.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from .ast_chunk import AstChunk
+from flynt.state import State
+
+
+import ast
+
+
+def is_percent_format(node):
+    return all(
+        [
+            isinstance(node, ast.BinOp),
+            isinstance(node.op, ast.Mod),
+            isinstance(node.left, ast.Str),
+        ]
+    )
+
+
+class PercentFmtFinder(ast.NodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.candidates: List[AstChunk] = []
+
+    def visit_BinOp(self, node: ast.BinOp) -> None:
+        """
+        Finds all nodes that are string concatenations with a literal.
+        """
+        if is_percent_format(node):
+            self.candidates.append(AstChunk(node))
+        else:
+            self.generic_visit(node)
+
+
+def percent_candidates(code: str, state: State) -> List[AstChunk]:
+    tree = ast.parse(code)
+
+    finder = PercentFmtFinder()
+    finder.visit(tree)
+
+    state.percent_candidates += len(finder.candidates)
+
+    return finder.candidates

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -158,7 +158,7 @@ class CodeEditor:
 
         For example, we might not want to change multiple lines."""
         if contract_lines:
-            if get_quote_type(str(chunk)) in (qt.triple_double, qt.triple_single):
+            if get_quote_type(self.code_in_chunk(chunk)) in (qt.triple_double, qt.triple_single):
                 lines = converted.split("\\n")
                 lines[-1] += rest
                 lines_fit = all(

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -88,8 +88,13 @@ class CodeEditor:
             full_lines = range(start_line, end_line)
             for line in full_lines:
                 result.append(self.src_lines[line])
-            result.append(self.src_lines[end_idx][:end_idx])
+            result.append(self.src_lines[end_line][:end_idx])
         return "\n".join(result)
+
+    def code_in_chunk(self, chunk: Union[Chunk, AstChunk]):
+        return self.code_between(
+            chunk.start_line, chunk.start_idx, chunk.end_line, chunk.end_idx
+        )
 
     def fill_up_to(self, chunk: Union[Chunk, AstChunk]) -> None:
         start_line, start_idx, _ = (chunk.start_line, chunk.start_idx, chunk.end_idx)

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -85,7 +85,7 @@ class CodeEditor:
             result.append(self.src_lines[start_line][start_idx:end_idx])
         else:
             result.append(self.src_lines[start_line][start_idx:])
-            full_lines = range(start_line, end_line)
+            full_lines = range(start_line+1, end_line)
             for line in full_lines:
                 result.append(self.src_lines[line])
             result.append(self.src_lines[end_line][:end_idx])

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -85,7 +85,7 @@ class CodeEditor:
             result.append(self.src_lines[start_line][start_idx:end_idx])
         else:
             result.append(self.src_lines[start_line][start_idx:])
-            full_lines = range(start=start_line, stop=end_line)
+            full_lines = range(start_line, end_line)
             for l in full_lines:
                 result.append(self.src_lines[l])
             result.append(self.src_lines[end_idx][:end_idx])

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -2,7 +2,7 @@ import logging
 import re
 import string
 import sys
-from functools import cache, partial
+from functools import lru_cache, partial
 from typing import Callable, List, Optional, Tuple, Union
 
 from flynt.candidates.ast_call_candidates import call_candidates
@@ -93,7 +93,7 @@ class CodeEditor:
             result.append(self.src_lines[end_line][:end_idx])
         return "\n".join(result)
 
-    @cache
+    @lru_cache(None)
     def code_in_chunk(self, chunk: Union[Chunk, AstChunk]):
         return self.code_between(
             chunk.start_line, chunk.start_idx, chunk.end_line, chunk.end_idx

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -222,7 +222,9 @@ def fstringify_code_by_line(code: str, state: State) -> Tuple[str, int]:
     """returns fstringified version of the code and amount of lines edited."""
 
     def candidates(code, state):
-        return percent_candidates(code, state) + call_candidates(code, state)
+        chunks = percent_candidates(code, state) + call_candidates(code, state)
+        chunks.sort(key=lambda c: (c.start_line, c.start_idx))
+        return chunks
 
     return _transform_code(
         code,

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -2,7 +2,7 @@ import logging
 import re
 import string
 import sys
-from functools import partial
+from functools import partial, cache
 from typing import Callable, List, Optional, Tuple, Union
 
 from flynt.candidates.ast_call_candidates import call_candidates
@@ -92,6 +92,7 @@ class CodeEditor:
             result.append(self.src_lines[end_line][:end_idx])
         return "\n".join(result)
 
+    @cache
     def code_in_chunk(self, chunk: Union[Chunk, AstChunk]):
         return self.code_between(
             chunk.start_line, chunk.start_idx, chunk.end_line, chunk.end_idx
@@ -132,7 +133,7 @@ class CodeEditor:
             quote_type = (
                 qt.double
                 if chunk.string_in_string and chunk.n_lines == 1
-                else chunk.quote_type
+                else get_quote_type(self.code_in_chunk(chunk))
             )
         except FlyntException:
             quote_type = qt.double

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -74,6 +74,23 @@ class CodeEditor:
         self.output = "".join(self.results)[:-1]
         return self.output, self.count_expressions
 
+    def code_between(
+        self, start_line: int, start_idx: int, end_line: int, end_idx: int
+    ) -> str:
+        """get source code in the original between two locations."""
+        assert end_line >= start_line
+        result = []
+        if start_line == end_line:
+            assert end_idx >= start_idx
+            result.append(self.src_lines[start_line][start_idx:end_idx])
+        else:
+            result.append(self.src_lines[start_line][start_idx:])
+            full_lines = range(start=start_line, stop=end_line)
+            for l in full_lines:
+                result.append(self.src_lines[l])
+            result.append(self.src_lines[end_idx][:end_idx])
+        return "\n".join(result)
+
     def fill_up_to(self, chunk: Union[Chunk, AstChunk]) -> None:
         start_line, start_idx, _ = (chunk.start_line, chunk.start_idx, chunk.end_idx)
         if start_line == self.last_line:

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -86,8 +86,8 @@ class CodeEditor:
         else:
             result.append(self.src_lines[start_line][start_idx:])
             full_lines = range(start_line, end_line)
-            for l in full_lines:
-                result.append(self.src_lines[l])
+            for line in full_lines:
+                result.append(self.src_lines[line])
             result.append(self.src_lines[end_idx][:end_idx])
         return "\n".join(result)
 

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -5,8 +5,9 @@ import sys
 from functools import partial
 from typing import Callable, List, Optional, Tuple, Union
 
-from flynt.candidates import split
+from flynt.candidates.ast_call_candidates import call_candidates
 from flynt.candidates.ast_chunk import AstChunk
+from flynt.candidates.ast_percent_candidates import percent_candidates
 from flynt.candidates.chunk import Chunk
 from flynt.exceptions import FlyntException
 from flynt.format import QuoteTypes as qt
@@ -218,9 +219,13 @@ class CodeEditor:
 
 def fstringify_code_by_line(code: str, state: State) -> Tuple[str, int]:
     """returns fstringified version of the code and amount of lines edited."""
+
+    def candidates(code, state):
+        return percent_candidates(code, state) + call_candidates(code, state)
+
     return _transform_code(
         code,
-        partial(split.get_fstringify_chunks, lexer_context=state.lexer_context),
+        partial(candidates, state=state),
         partial(transform_chunk, state=state),
         state,
     )

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -2,7 +2,7 @@ import logging
 import re
 import string
 import sys
-from functools import partial, cache
+from functools import cache, partial
 from typing import Callable, List, Optional, Tuple, Union
 
 from flynt.candidates.ast_call_candidates import call_candidates

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -130,9 +130,13 @@ class CodeEditor:
         if contains_comment(self.code_in_chunk(chunk)):
             return
 
+        # skip raw strings
+        if self.code_in_chunk(chunk)[0] == "r":
+            return
+
+        # skip lines with # noqa comment
         for line in self.src_lines[chunk.start_line : chunk.end_line + 1]:
             if noqa_regex.findall(line):
-                # user does not wish for this line to be converted.
                 return
 
         try:

--- a/src/flynt/string_concat/candidates.py
+++ b/src/flynt/string_concat/candidates.py
@@ -1,5 +1,5 @@
 import ast
-from typing import List, Iterable
+from typing import Iterable, List
 
 from flynt.candidates.ast_chunk import AstChunk
 from flynt.state import State

--- a/src/flynt/string_concat/candidates.py
+++ b/src/flynt/string_concat/candidates.py
@@ -1,5 +1,5 @@
 import ast
-from typing import Generator, List
+from typing import List, Iterable
 
 from flynt.candidates.ast_chunk import AstChunk
 from flynt.state import State
@@ -30,7 +30,7 @@ class ConcatHound(ast.NodeVisitor):
             self.generic_visit(node)
 
 
-def concat_candidates(code: str, state: State) -> Generator[AstChunk, None, None]:
+def concat_candidates(code: str, state: State) -> Iterable[AstChunk]:
     tree = ast.parse(code)
 
     ch = ConcatHound()
@@ -38,4 +38,4 @@ def concat_candidates(code: str, state: State) -> Generator[AstChunk, None, None
 
     state.concat_candidates += len(ch.victims)
 
-    yield from ch.victims
+    return ch.victims

--- a/src/flynt/transform/transform.py
+++ b/src/flynt/transform/transform.py
@@ -1,6 +1,7 @@
 import ast
 import copy
 import logging
+import traceback
 from typing import Tuple
 
 from flynt.exceptions import ConversionRefused
@@ -37,6 +38,7 @@ def transform_chunk(
         state.invalid_conversions += 1
         return code, False
     except Exception:
+        traceback.print_exc()
         log.exception("Exception during conversion of code '%s'", code)
         state.invalid_conversions += 1
         return code, False

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -7,6 +7,8 @@ from astor.string_repr import pretty_string
 from flynt.exceptions import ConversionRefused
 from flynt.format import QuoteTypes, set_quote_type
 from flynt.linting.fstr_lint import FstrInliner
+import tokenize
+import io
 
 
 def nicer_pretty_string(
@@ -77,3 +79,11 @@ def fixup_transformed(tree: ast.AST, quote_type: Optional[str] = None) -> str:
     new_code = new_code.replace("\n", "\\n")
     new_code = new_code.replace("\t", "\\t")
     return new_code
+
+
+def contains_comment(code: str) -> bool:
+    tokens = tokenize.generate_tokens(io.StringIO(code).readline)
+    for token in tokens:
+        if token.type == tokenize.COMMENT:
+            return True
+    return False

--- a/src/flynt/utils.py
+++ b/src/flynt/utils.py
@@ -1,4 +1,6 @@
 import ast
+import io
+import tokenize
 from typing import Optional
 
 import astor
@@ -7,8 +9,6 @@ from astor.string_repr import pretty_string
 from flynt.exceptions import ConversionRefused
 from flynt.format import QuoteTypes, set_quote_type
 from flynt.linting.fstr_lint import FstrInliner
-import tokenize
-import io
 
 
 def nicer_pretty_string(

--- a/test/integration/utils.py
+++ b/test/integration/utils.py
@@ -10,6 +10,7 @@ EXCLUDED = {
     "multiline_limit.py",
 }
 samples = {p.name for p in (int_test_path / "samples_in").glob("*.py")} - EXCLUDED
+# samples = {"multiline_1.py"}
 concat_samples = {p.name for p in (int_test_path / "samples_in_concat").glob("*.py")}
 
 

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -4,7 +4,8 @@ from flynt.candidates import split
 from flynt.code_editor import CodeEditor
 from flynt.format import get_quote_type
 
-
+s0 = """'%s' % (
+                    v['key'])"""
 s1 = """s = '%s' % (
                     v['key'])"""
 
@@ -17,9 +18,22 @@ s2 = """\"%(a)-6d %(a)s" % d"""
         s1, s2
     ],
 )
-def test_code_between(s_in):
+def test_code_between_qoute_types(s_in):
 
     chunk = set(split.get_fstringify_chunks(s_in)).pop()
     editor = CodeEditor(s_in, None, lambda *args: None, None)
 
     assert get_quote_type(editor.code_in_chunk(chunk)) == get_quote_type(str(chunk))
+
+
+@pytest.mark.parametrize(
+    "s_in",
+    [
+        s0, s2
+    ],
+)
+def test_code_between_exact(s_in):
+    chunk = set(split.get_fstringify_chunks(s_in)).pop()
+    editor = CodeEditor(s_in, None, lambda *args: None, None)
+
+    assert editor.code_in_chunk(chunk) == s_in

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -1,0 +1,23 @@
+import pytest
+
+from flynt.candidates import split
+from flynt.code_editor import CodeEditor
+from flynt.format import get_quote_type
+
+
+s1 = """s = '%s' % (
+                    v['key'])"""
+
+
+@pytest.mark.parametrize(
+    "s_in",
+    [
+        s1,
+    ],
+)
+def test_code_between(s_in):
+
+    chunk = set(split.get_fstringify_chunks(s_in)).pop()
+    editor = CodeEditor(s_in, None, lambda *args: None, None)
+
+    assert get_quote_type(editor.code_in_chunk(chunk)) == get_quote_type(str(chunk))

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -14,9 +14,7 @@ s2 = """\"%(a)-6d %(a)s" % d"""
 
 @pytest.mark.parametrize(
     "s_in",
-    [
-        s1, s2
-    ],
+    [s1, s2],
 )
 def test_code_between_qoute_types(s_in):
 
@@ -28,9 +26,7 @@ def test_code_between_qoute_types(s_in):
 
 @pytest.mark.parametrize(
     "s_in",
-    [
-        s0, s2
-    ],
+    [s0, s2],
 )
 def test_code_between_exact(s_in):
     chunk = set(split.get_fstringify_chunks(s_in)).pop()

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -8,11 +8,13 @@ from flynt.format import get_quote_type
 s1 = """s = '%s' % (
                     v['key'])"""
 
+s2 = """\"%(a)-6d %(a)s" % d"""
+
 
 @pytest.mark.parametrize(
     "s_in",
     [
-        s1,
+        s1, s2
     ],
 )
 def test_code_between(s_in):

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -137,8 +137,7 @@ def test_invalid_conversion(state: State):
 
 
 def test_invalid_conversion_names(state: State):
-    s_in = """a = 'my string {var}, but also {f!b}
-     and {cada_bra!a}'.format(var, f, cada_bra)"""
+    s_in = """a = 'but also {f!b} and {cada_bra!a}'.format(f, cada_bra)"""
     s_expected = s_in
 
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
@@ -539,10 +538,7 @@ def test_unknown_mod_percend_dictionary(state: State):
     assert out == s_in
 
 
-s_in_mixed_quotes = """'one is {} '
-"and two is {}".format(one, two) 
-""".strip()
-
+s_in_mixed_quotes = """'one is {} '"and two is {}".format(one, two)"""
 
 def test_mixed_quote_types(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""
@@ -553,15 +549,10 @@ def test_mixed_quote_types(state: State):
     assert out == expected
 
 
-s_in_mixed_quotes_unsafe = """'one is "{}" '
-"and two is {}".format('"'.join(one), two) 
-""".strip()
-
+s_in_mixed_quotes_unsafe = """'one is "{}" '"and two is {}".format('"'.join(one), two)"""
 
 def test_mixed_quote_types_unsafe(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""
-
-    # expected = '''f"one is {one} and two is {two}"'''
 
     out, count = code_editor.fstringify_code_by_line(s_in_mixed_quotes_unsafe, state)
     assert out == s_in_mixed_quotes_unsafe
@@ -579,8 +570,7 @@ def test_super_call(state: State):
 
 
 escaped = """
-var = 'baz'
-'foo " %s \\' bar' % var
+var = 'baz''foo " %s \\' bar' % var
 """
 
 expected_escaped = """
@@ -597,8 +587,7 @@ def test_escaped_mix(state: State):
 
 
 escaped_2 = """
-var = 'baz'
-"foo ' %s \\" bar" % var
+var = 'baz'"foo ' %s \\" bar" % var
 """
 
 expected_escaped_2 = """

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -543,7 +543,7 @@ s_in_mixed_quotes = """'one is {} '"and two is {}".format(one, two)"""
 def test_mixed_quote_types(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""
 
-    expected = '''f"one is {one} and two is {two}"'''
+    expected = """f'one is {one} and two is {two}'"""
 
     out, count = code_editor.fstringify_code_by_line(s_in_mixed_quotes, state)
     assert out == expected
@@ -591,7 +591,7 @@ var = 'baz'"foo ' %s \\" bar" % var
 """
 
 expected_escaped_2 = """
-var = f"bazfoo ' {var} \\" bar"
+var = f'bazfoo \\' {var} " bar'
 """
 
 

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -540,6 +540,7 @@ def test_unknown_mod_percend_dictionary(state: State):
 
 s_in_mixed_quotes = """'one is {} '"and two is {}".format(one, two)"""
 
+
 def test_mixed_quote_types(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""
 
@@ -549,7 +550,8 @@ def test_mixed_quote_types(state: State):
     assert out == expected
 
 
-s_in_mixed_quotes_unsafe = """'one is "{}" '"and two is {}".format('"'.join(one), two)"""
+s_in_mixed_quotes_unsafe = """'one "{}" '", two {}".format('"'.join(one), two)"""
+
 
 def test_mixed_quote_types_unsafe(state: State):
     """Test that a multiline, mixed-quotes expression is transformed."""


### PR DESCRIPTION
This is a long due refactoring. At the time flynt was created, `ast` module didn't allow to find both start and end of the expression in the source code, therefore it was needed to have another, more complicated solution. Since python 3.8, `ast` allows to find exact start and end of the expression in the source code, and this was already used in string concatenations.

This PR moves functionality over to the new mechanism, leaving deletion of legacy code for future PRs.