### PR TITLE
Uniform files list by using unix path

### DIFF
--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -314,6 +314,8 @@ def _resolve_files(
         else:
             files.append(abs_path)
 
+    files = [f.replace("\\", "/") for f in files]
+    _blacklist = {f.replace("\\", "/") for f in _blacklist}
     files = [f for f in files if all(b not in f for b in _blacklist)]
     return files
 


### PR DESCRIPTION
Uniform files list by using unix path.

Fix that if your running `flynt` on different OS, the "exclude" argument/setting can not work because is depending of OS path separator.