### PR TITLE
Convert percent format if the right node is a List

### DIFF
--- a/src/flynt/transform/FstringifyTransformer.py
+++ b/src/flynt/transform/FstringifyTransformer.py
@@ -43,7 +43,7 @@ class FstringifyTransformer(ast.NodeTransformer):
         """Convert `ast.BinOp` to `ast.JoinedStr` f-string.
 
         Currently only if a string literal `ast.Str` is on the left side of the `%`
-        and one of `ast.Tuple`, `ast.Name`, `ast.Dict` is on the right
+        and one of `ast.Tuple`, `ast.List`, `ast.Name`, `ast.Dict` is on the right
 
         Args:
             node (ast.BinOp): The node to convert to a f-string

--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -30,7 +30,9 @@ def is_percent_stringify(node: ast.BinOp) -> bool:
     return (
         isinstance(node.left, ast.Str)
         and isinstance(node.op, ast.Mod)
-        and isinstance(node.right, tuple([ast.Tuple, ast.Dict, *supported_operands]))
+        and isinstance(
+            node.right, tuple([ast.Tuple, ast.List, ast.Dict, *supported_operands])
+        )
     )
 
 
@@ -183,6 +185,25 @@ def transform_tuple(node: ast.BinOp, *, aggressive: bool = False) -> ast.JoinedS
     return ast.JoinedStr(segments)
 
 
+def transform_list(node: ast.BinOp, *, aggressive: bool = False) -> ast.JoinedStr:
+    """Convert a `BinOp` `%` formatted str with a list on the right to an f-string.
+
+    Takes an ast.BinOp representing `"1. %s 2. %s" % [a, b]`
+    and converted it to a ast.JoinedStr representing `f"1. {a} 2. {b}"`
+    Borrow the core logic by converting the list into a ast.Tuple
+
+    Args:
+       node (ast.BinOp): The node to convert to a f-string
+
+    Returns ast.JoinedStr (f-string)
+    """
+    assert isinstance(node.right, ast.List)
+
+    # convert the list to a tuple to use that code
+    node.right = ast.Tuple(elts=node.right.elts)
+    return transform_tuple(node, aggressive=aggressive)
+
+
 def transform_generic(
     node: ast.BinOp,
     aggressive: bool = False,
@@ -232,6 +253,9 @@ def transform_binop(
 
     if isinstance(node.right, ast.Tuple):
         return transform_tuple(node, aggressive=aggressive)
+
+    if isinstance(node.right, ast.List):
+        return transform_list(node, aggressive=aggressive)
 
     if isinstance(node.right, ast.Dict):
         # todo adapt transform dict to Dict literal

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -72,6 +72,14 @@ def test_percent_tuple(state: State):
     assert s_out == s_expected
 
 
+def test_percent_list(state: State):
+    s_in = """print("%s %s " % [var+var, abc])"""
+    s_expected = """print(f"{var + var} {abc} ")"""
+
+    s_out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert s_out == s_expected
+
+
 def test_part_of_concat(state: State):
     s_in = """print('blah{}'.format(thing) + 'blah' + otherThing + "is %f" % x)"""
     s_expected = """print(f'blah{thing}' + 'blah' + otherThing + f"is {x:f}")"""


### PR DESCRIPTION
Convert percent format if the right node is a List. Convert the list to a tuple to use that code.