### PR TITLE
Replace astor with ast.unparse() and Black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "astor",
+    "black",
     "tomli>=1.1.0; python_version < '3.11'"
 ]
 

--- a/src/flynt/utils/utils.py
+++ b/src/flynt/utils/utils.py
@@ -3,13 +3,16 @@ import io
 import tokenize
 from typing import Optional, Union
 
+from black import Mode, format_str
+
 from flynt.exceptions import ConversionRefused
 from flynt.linting.fstr_lint import FstrInliner
 from flynt.utils.format import QuoteTypes, set_quote_type
 
 
 def ast_to_string(node: ast.AST) -> str:
-    return ast.unparse(node).rstrip()
+    # ast.unparse() favors single quotes, use Black to turn them into double quotes
+    return format_str(ast.unparse(node), mode=Mode()).rstrip()
 
 
 def is_str_literal(node: ast.AST) -> bool:

--- a/src/flynt/utils/utils.py
+++ b/src/flynt/utils/utils.py
@@ -3,33 +3,13 @@ import io
 import tokenize
 from typing import Optional, Union
 
-import astor
-from astor.string_repr import pretty_string
-
 from flynt.exceptions import ConversionRefused
 from flynt.linting.fstr_lint import FstrInliner
 from flynt.utils.format import QuoteTypes, set_quote_type
 
 
-def nicer_pretty_string(
-    s,
-    embedded,
-    current_line,
-    uni_lit=False,
-):
-    r = repr(s)
-    if "\\x" in r:
-        # If the string contains an escape sequence,
-        # we need to work around a bug in upstream astor;
-        # the easiest workaround is to just use the repr
-        # of the string and be done with it.
-        return r
-    return pretty_string(s, embedded, current_line, uni_lit=uni_lit)
-
-
 def ast_to_string(node: ast.AST) -> str:
-    # TODO: this could use `ast.unparse` when targeting Python 3.9+ only.
-    return astor.to_source(node, pretty_string=nicer_pretty_string).rstrip()
+    return ast.unparse(node).rstrip()
 
 
 def is_str_literal(node: ast.AST) -> bool:

--- a/test/integration/expected_out/multiline_keep.py
+++ b/test/integration/expected_out/multiline_keep.py
@@ -5,5 +5,5 @@ text = f"""
 
 [flake8]
 max-line-length={length}
-inline-quotes="{quotes}\"
+inline-quotes="{quotes}"
 """

--- a/test/test_str_concat/test_candidates.py
+++ b/test/test_str_concat/test_candidates.py
@@ -28,7 +28,7 @@ def test_find_victims_primitives(pycode_with_2_concats: str):
     assert len(ch.victims) == 2
 
     v1, v2 = ch.victims
-    assert str(v1) == "a + ' World'"
+    assert str(v1) == 'a + " World"'
     assert 'a + " World"' in pycode_with_2_concats.split("\n")[v1.start_line]
 
 
@@ -40,7 +40,7 @@ def test_find_victims_api(pycode_with_2_concats: str, state: State):
     assert len(lst) == 2
 
     v1, v2 = lst
-    assert str(v1) == "a + ' World'"
+    assert str(v1) == 'a + " World"'
     assert 'a + " World"' in pycode_with_2_concats.split("\n")[v1.start_line]
 
 
@@ -53,4 +53,4 @@ def test_find_victims_parens(state: State):
     assert len(lst) == 1
 
     v1 = lst[0]
-    assert str(v1) == """'blah' + (thing - 1)"""
+    assert str(v1) == '''"blah" + (thing - 1)'''

--- a/test/test_str_concat/test_transformer.py
+++ b/test/test_str_concat/test_transformer.py
@@ -90,7 +90,7 @@ def test_string_in_string():
 def test_concats_fstring():
 
     txt = """print(f'blah{thing}' + 'blah' + otherThing + f"is {x:d}")"""
-    expected = """print(f'blah{thing}blah{otherThing}is {x:d}')"""
+    expected = """print(f"blah{thing}blah{otherThing}is {x:d}")"""
 
     new, changed = transform_concat_from_str(txt)
 
@@ -105,7 +105,7 @@ def test_string_in_string_x3():
     new, changed = transform_concat_from_str(txt)
 
     assert changed
-    assert "'blah' +" in new
+    assert '"blah" +' in new
 
 
 def test_existing_fstr():
@@ -133,7 +133,7 @@ def test_existing_fstr_expr():
 def test_embedded_fstr():
 
     txt = """print(f"{f'blah{var}' + abc}blah")"""
-    expected = """print(f'blah{var}{abc}blah')"""
+    expected = """print(f"blah{var}{abc}blah")"""
 
     new, changed = transform_concat_from_str(txt)
 


### PR DESCRIPTION
[Astor] isn't yet compatible with Python 3.14 and the [changes in the `ast` standard library module] (see "Deprecated since" notes in the docs). A fix (see berkerpeksag/astor#217) is planned for Astor 0.9 (see berkerpeksag/astor#229). On the other hand, [`ast.unparse()`] has been in the standard library since Python 3.9, and Flynt has already dropped support for Python 3.8. Flynt could simply migrate from [Astor] to [`ast.unparse()`] and get Python 3.14 support through that.

This PR
- [x] changes `ast_to_string()` to use [`ast.unparse()`] instead of `astor.to_source()`
- [x] post-processes the result using [Black] to get double quotes instead of single quotes
- [x] adds [Black] as a dependency

To do before merge:
- [x] investigate the `insert_constant_str.py` test failure
- [ ] fix  the `insert_constant_str.py` test failure
- [ ] investigate and fix the parentheses test failure
- [ ] investigate and fix the `test_chain_fmt_3` test failure

Next steps:
- fix #195 and support for Python 3.14 by replacing references to `ast.Str` and `ast.Num` with `ast.Constant` plus any additional required logic

[Astor]: /berkerpeksag/astor
[changes in the `ast` standard library module]: https://docs.python.org/3/library/ast.html#node-classes
[`ast.unparse()`]: https://docs.python.org/3/library/ast.html#ast.unparse
[Black]: /psf/black

See also:
- #195