### PR TITLE
Fix char count reduction bug

### DIFF
--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -177,7 +177,7 @@ def fstringify_files(
                 changed_files += 1
                 total_expressions += result.n_changes
             total_charcount_original += result.original_length
-            total_charcount_new += result.n_changes
+            total_charcount_new += result.new_length
             status = "modified" if result.n_changes else "no change"
         else:
             status = "failed"

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -213,3 +213,23 @@ def test_uniform_path(fake_folder_tree):
 
     result = _resolve_files([fake_folder_tree], uniform_path_exclude)
     assert len(result) == uniform_path_count_result
+
+
+def test_fstringify_files_charcount(tmp_path, monkeypatch):
+    source = "'{}'.format(1)\n"
+    f = tmp_path / "a.py"
+    f.write_text(source)
+
+    captured = {}
+
+    def fake_print_report(state, found_files, changed_files, total_cc_new, total_cc_original, total_expr, total_time):
+        captured["new"] = total_cc_new
+        captured["orig"] = total_cc_original
+
+    monkeypatch.setattr(api, "_print_report", fake_print_report)
+
+    state = State()
+    api.fstringify_files([str(f)], state)
+
+    assert captured["orig"] == len(source)
+    assert captured["new"] == len("f'{1}'\n")

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -218,11 +218,19 @@ def test_uniform_path(fake_folder_tree):
 def test_fstringify_files_charcount(tmp_path, monkeypatch):
     source = "'{}'.format(1)\n"
     f = tmp_path / "a.py"
-    f.write_text(source)
+    f.write_text(source, newline="")
 
     captured = {}
 
-    def fake_print_report(state, found_files, changed_files, total_cc_new, total_cc_original, total_expr, total_time):
+    def fake_print_report(
+        state,
+        found_files,
+        changed_files,
+        total_cc_new,
+        total_cc_original,
+        total_expr,
+        total_time,
+    ):
         captured["new"] = total_cc_new
         captured["orig"] = total_cc_original
 

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -218,7 +218,8 @@ def test_uniform_path(fake_folder_tree):
 def test_fstringify_files_charcount(tmp_path, monkeypatch):
     source = "'{}'.format(1)\n"
     f = tmp_path / "a.py"
-    f.write_text(source, newline="")
+    with open(f, "w", newline="") as fh:
+        fh.write(source)
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- compute total character count for new code correctly
- add regression test verifying total character count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbe82e7c08326ac5b84ad3afab100