### PR TITLE
Fix string.format assertion on variable names

### DIFF
--- a/src/flynt/candidates/ast_call_candidates.py
+++ b/src/flynt/candidates/ast_call_candidates.py
@@ -11,7 +11,10 @@ def is_call_format(node):
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "format"
-        and isinstance(node.func.value, (ast.Str, ast.Name))
+        # We only support literal format strings, not variables holding
+        # format strings. `joined_string` will refuse non literals, but
+        # filtering them here avoids unnecessary processing.
+        and isinstance(node.func.value, ast.Str)
     )
 
 

--- a/src/flynt/transform/format_call_transforms.py
+++ b/src/flynt/transform/format_call_transforms.py
@@ -15,10 +15,12 @@ def joined_string(
     aggressive: bool = False,
 ) -> Union[ast.JoinedStr, ast.Str]:
     """Transform a "...".format() call node into a f-string node."""
-    assert isinstance(fmt_call.func, ast.Attribute) and isinstance(
-        fmt_call.func.value,
-        ast.Str,
-    )
+    if not (
+        isinstance(fmt_call.func, ast.Attribute)
+        and isinstance(fmt_call.func.value, ast.Str)
+    ):
+        raise ConversionRefused("Only literal format strings are supported")
+
     string = fmt_call.func.value.s
     var_map: Dict[Any, Any] = {kw.arg: kw.value for kw in fmt_call.keywords}
     inserted_value_nodes = []

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -202,3 +202,11 @@ def test_disabled_transforms():
         '"my string {:.2f}" % var',
         state=State(transform_percent=False),
     )[1]
+
+
+def test_skip_variable_format(state: State):
+    code = 'template = "Hello {0}"\nresult = template.format(name)'
+
+    new, changed = transform_chunk_from_str(code, state)
+
+    assert not changed


### PR DESCRIPTION
## Summary
- skip format calls on non-literal strings early
- guard joined_string with a proper ConversionRefused
- add regression test for variable format call

## Testing
- `pre-commit run --files src/flynt/transform/format_call_transforms.py src/flynt/candidates/ast_call_candidates.py test/test_transform.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a78bf5c48326ba9519bffda4f550