### PR TITLE
Fix DeprecationWarnings for ast.Str

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "CLI tool to convert a python project's %-formatted strings to f-strings."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Ilya Kamenshchikov" },
 ]

--- a/src/flynt/utils/utils.py
+++ b/src/flynt/utils/utils.py
@@ -34,22 +34,16 @@ def ast_to_string(node: ast.AST) -> str:
 
 def is_str_literal(node: ast.AST) -> bool:
     """Return ``True`` if ``node`` is a string literal or an f-string."""
-    return isinstance(node, (ast.JoinedStr, ast.Str)) or (
-        isinstance(node, ast.Constant) and isinstance(node.value, str)
-    )
+    return isinstance(node, ast.JoinedStr) or is_str_constant(node)
 
 
 def is_str_constant(node: ast.AST) -> bool:
     """Return ``True`` if ``node`` represents a plain string constant."""
-    return (
-        isinstance(node, ast.Constant) and isinstance(node.value, str)
-    ) or isinstance(node, ast.Str)
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)
 
 
 def get_str_value(node: ast.AST) -> str:
     """Extract the string value from ``node`` which must be a str constant."""
-    if isinstance(node, ast.Str):
-        return node.s
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
     raise TypeError(f"Expected string constant, got {type(node)}")
@@ -124,17 +118,6 @@ def ast_formatted_value(
 
 def ast_string_node(string: str) -> ast.Constant:
     return ast.Constant(value=string)
-
-
-def check_is_string_node(tree: ast.AST):
-    """Raise an exception is tree doesn't represent a string"""
-    if isinstance(tree, ast.Module):
-        tree = tree.body[0]
-    if isinstance(tree, ast.Expr):
-        tree = tree.value
-    assert isinstance(tree, (ast.JoinedStr, ast.Str, ast.Constant)), (
-        f"found {type(tree)}"
-    )
 
 
 def fixup_transformed(tree: ast.AST, quote_type: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary
- avoid referencing `ast.Str` as it is a subclass of ast.Constant on python>= 3.8
- we were already not explicitly supporting py 3.7, now this is moved to required python version in pyproject.toml

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883da24fb488326bfe20a4507d729b2