### PR TITLE
Add support for flynt skip comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and now results in `'`, as in `f'first part {one}second part {two}'`. I think it
 in the output. At the same time it's a huge simplification of the source code that should help 
 maintain and develop this project in the future.
 
+* Added `# flynt: skip` comment to ignore a line during conversion without using `# noqa`.
+
 
 #### v.0.77
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Add a new section to `.pre-commit-config.yaml`:
 
 This will run flynt on all modified files before committing.
 
-You can skip conversion of certain lines by adding `# noqa [: anything else] flynt [anything else]`
+You can skip conversion of certain lines by adding `# noqa [: anything else] flynt [anything else]` or `# flynt: skip`
 
 
 ### Configuration files

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -20,6 +20,7 @@ from flynt.utils.format import get_quote_type
 from flynt.utils.utils import contains_comment
 
 noqa_regex = re.compile("#[ ]*noqa.*flynt")
+flynt_skip_regex = re.compile(r"#\s*flynt:\s*skip")
 
 log = logging.getLogger(__name__)
 
@@ -133,9 +134,9 @@ class CodeEditor:
         if self.code_in_chunk(chunk)[0] == "r":
             return
 
-        # skip lines with # noqa comment
+        # skip lines with # noqa comment or # flynt: skip
         for line in self.src_lines[chunk.start_line : chunk.end_line + 1]:
-            if noqa_regex.findall(line):
+            if noqa_regex.findall(line) or flynt_skip_regex.findall(line):
                 return
 
         try:

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -138,6 +138,13 @@ def test_noqa_other(state: State):
     assert s_out == s_expected
 
 
+def test_flynt_skip(state: State):
+    s_in = """a = 'my string {}, but also {} and {}'.format(var, f, cada_bra)  # flynt: skip"""
+    s_expected = """a = 'my string {}, but also {} and {}'.format(var, f, cada_bra)  # flynt: skip"""
+
+    s_out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert s_out == s_expected
+
 def test_multiline(state: State):
     s_in = """a = 'my string {}, but also {} and {}'.format(\nvar, \nf, \ncada_bra)"""
     s_expected = """a = f'my string {var}, but also {f} and {cada_bra}'"""

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -145,6 +145,7 @@ def test_flynt_skip(state: State):
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
+
 def test_multiline(state: State):
     s_in = """a = 'my string {}, but also {} and {}'.format(\nvar, \nf, \ncada_bra)"""
     s_expected = """a = f'my string {var}, but also {f} and {cada_bra}'"""


### PR DESCRIPTION
## Summary
- skip conversion when a line contains `# flynt: skip`
- document the new comment in README and CHANGELOG
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883dc3d4b7883268526757199273096