### PR TITLE
Switch to ast.unparse for source generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ F-Strings:
 
 ### Installation
 
-`pip install flynt`. It requires Python version 3.7+.
+`pip install flynt`. It requires Python version 3.9+.
 
 ### Usage
 
@@ -79,12 +79,12 @@ optional arguments:
                         Replace string concatenations (defined as +
                         operations involving string literals) with
                         f-strings. Available only if flynt is
-                        installed with 3.8+ interpreter.
+                        installed with a 3.9+ interpreter.
   -tj, --transform-joins
                         Replace static joins (where the joiner is a
                         string literal and the joinee is a static-
                         length list) with f-strings. Available only
-                        if flynt is installed with 3.8+ interpreter.
+                        if flynt is installed with a 3.9+ interpreter.
   -f, --fail-on-change  Fail when changing files (for linting
                         purposes)
   -a, --aggressive      Include conversions with potentially changed
@@ -174,6 +174,6 @@ Furthermore, some arguments cause formatting of strings to throw exceptions. One
 
 ### Other Credits / Dependencies / Links
 
-- [astor](https://github.com/berkerpeksag/astor) is used to turn the transformed AST back into code.
+- Python's built-in `ast.unparse` is used to turn the transformed AST back into code.
 - Thanks to folks from [pyddf](https://www.pyddf.de/) for their support, advice and participation during spring hackathon 2019, in particular Holger Hass, Farid Muradov, Charlie Clark.
 - Logic finding the pyproject.toml and parsing it was partially copied from [black](https://github.com/psf/black) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "CLI tool to convert a python project's %-formatted strings to f-strings."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Ilya Kamenshchikov" },
 ]
@@ -19,7 +19,6 @@ keywords = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -29,7 +28,6 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "astor",
     "tomli>=1.1.0; python_version < '3.11'"
 ]
 
@@ -57,18 +55,10 @@ include = [
     "/src",
 ]
 
-[tool.pytest.ini_options]
-filterwarnings = [
-    # Ignore every warning whose ``__module__`` starts with ``astor``
-    "ignore:::astor\\..*",
-]
+
 
 [tool.mypy]
 exclude = "test/integration/(actual|expected|samples).*"
-
-[[tool.mypy.overrides]]
-module = "astor"
-ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 88

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -6,9 +6,7 @@ import os
 import sys
 import time
 from difflib import unified_diff
-from typing import Collection, List, Optional, Tuple
-
-import astor
+from typing import Collection, Iterable, List, Optional, Tuple
 
 from flynt.code_editor import (
     fstringify_code_by_line,
@@ -28,6 +26,16 @@ class FstringifyResult:
     original_length: int
     new_length: int
     content: str
+
+
+def _find_py_files(path: str) -> Iterable[Tuple[str, str]]:
+    """Yield ``(folder, filename)`` pairs for all Python files under ``path``."""
+    if not os.path.isdir(path):
+        yield os.path.split(path)
+        return
+    for srcpath, _, fnames in os.walk(path):
+        for fname in (f for f in fnames if f.endswith(".py")):
+            yield srcpath, fname
 
 
 def _fstringify_file(
@@ -307,7 +315,7 @@ def _resolve_files(
             sys.exit(1)
 
         if os.path.isdir(abs_path):
-            for folder, filename in astor.code_to_ast.find_py_files(abs_path):
+            for folder, filename in _find_py_files(abs_path):
                 files.append(os.path.join(folder, filename))
         else:
             files.append(abs_path)

--- a/src/flynt/candidates/ast_chunk.py
+++ b/src/flynt/candidates/ast_chunk.py
@@ -1,4 +1,4 @@
-"""Uses py3.8 AST to define a chunk of code as an AST node."""
+"""Uses Python 3.9 AST to define a chunk of code as an AST node."""
 
 import ast
 

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -112,7 +112,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         action="store_true",
         default=False,
         help="Replace string concatenations (defined as + operations involving string literals) "
-        "with f-strings. Available only if flynt is installed with 3.8+ interpreter.",
+        "with f-strings. Available only if flynt is installed with a 3.9+ interpreter.",
     )
 
     parser.add_argument(
@@ -121,7 +121,7 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         action="store_true",
         default=False,
         help="Replace static joins (where the joiner is a string literal and the joinee is a static-length list) "
-        "with f-strings. Available only if flynt is installed with 3.8+ interpreter.",
+        "with f-strings. Available only if flynt is installed with a 3.9+ interpreter.",
     )
 
     parser.add_argument(
@@ -176,16 +176,16 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         parser.print_usage()
         return 1
 
-    if args.transform_concats and sys.version_info < (3, 8):
+    if args.transform_concats and sys.version_info < (3, 9):
         raise Exception(
             f"""Transforming string concatenations is only possible with flynt
-                installed to a python3.8+ interpreter. Currently using {sys.version_info}.""",
+                installed to a python3.9+ interpreter. Currently using {sys.version_info}.""",
         )
 
-    if args.transform_joins and sys.version_info < (3, 8):
+    if args.transform_joins and sys.version_info < (3, 9):
         raise Exception(
             f"""Transforming joins is only possible with flynt
-                installed to a python3.8+ interpreter. Currently using {sys.version_info}.""",
+                installed to a python3.9+ interpreter. Currently using {sys.version_info}.""",
         )
 
     logging.basicConfig(

--- a/src/flynt/static_join/transformer.py
+++ b/src/flynt/static_join/transformer.py
@@ -2,6 +2,7 @@ import ast
 from typing import List, Tuple
 
 from flynt.static_join.utils import get_static_join_bits
+from flynt.utils.format import QuoteTypes
 from flynt.utils.utils import (
     ast_formatted_value,
     ast_string_node,
@@ -47,7 +48,7 @@ def transform_join(tree: ast.AST, *args, **kwargs) -> Tuple[str, bool]:
     new_tree = jt.visit(tree)
     changed = jt.counter > 0
     if changed:
-        new_code = fixup_transformed(new_tree)
+        new_code = fixup_transformed(new_tree, quote_type=QuoteTypes.double)
     else:
         new_code = ""
     return new_code, changed

--- a/src/flynt/utils/utils.py
+++ b/src/flynt/utils/utils.py
@@ -1,35 +1,23 @@
 import ast
 import io
+import re
 import tokenize
 from typing import Optional, Union
-
-import astor
-from astor.string_repr import pretty_string
 
 from flynt.exceptions import ConversionRefused
 from flynt.linting.fstr_lint import FstrInliner
 from flynt.utils.format import QuoteTypes, set_quote_type
 
 
-def nicer_pretty_string(
-    s,
-    embedded,
-    current_line,
-    uni_lit=False,
-):
-    r = repr(s)
-    if "\\x" in r:
-        # If the string contains an escape sequence,
-        # we need to work around a bug in upstream astor;
-        # the easiest workaround is to just use the repr
-        # of the string and be done with it.
-        return r
-    return pretty_string(s, embedded, current_line, uni_lit=uni_lit)
-
-
 def ast_to_string(node: ast.AST) -> str:
-    # TODO: this could use `ast.unparse` when targeting Python 3.9+ only.
-    return astor.to_source(node, pretty_string=nicer_pretty_string).rstrip()
+    """Convert ``node`` back into source code."""
+    txt = ast.unparse(node).rstrip()
+    # ``ast.unparse`` wraps ternary expressions in ``FormattedValue`` with
+    # redundant parentheses, e.g. ``f"{(a if c else b)}"``.  Remove them to
+    # match the style previously produced via ``astor``.
+    if isinstance(node, ast.JoinedStr):
+        txt = re.sub(r"\{\(([^{}]+?\sif\s[^{}]+?\selse\s[^{}]+?)\)\}", r"{\1}", txt)
+    return txt
 
 
 def is_str_literal(node: ast.AST) -> bool:
@@ -125,9 +113,19 @@ def fixup_transformed(tree: ast.AST, quote_type: Optional[str] = None) -> str:
     # check_is_string_node(tree)
     il = FstrInliner()
     il.visit(tree)
-    new_code = ast_to_string(tree)
+    try:
+        new_code = ast_to_string(tree)
+    except ValueError as exc:
+        # ``ast.unparse`` raises ``ValueError`` on invalid conversions prior to
+        # Python 3.12.  Treat this as a refused conversion so the caller can
+        # gracefully skip the transformation.
+        raise ConversionRefused(str(exc)) from exc
     if quote_type is None:
-        if new_code[:4] == 'f"""' or new_code[:3] == "'''" or new_code[:3] == '"""':
+        if isinstance(tree, ast.Constant) and isinstance(tree.value, str):
+            quote_type = QuoteTypes.double
+        elif isinstance(tree, ast.JoinedStr):
+            quote_type = QuoteTypes.double
+        elif new_code[:4] == 'f"""' or new_code[:3] == "'''" or new_code[:3] == '"""':
             quote_type = QuoteTypes.double
     if quote_type is not None:
         new_code = set_quote_type(new_code, quote_type)

--- a/test/integration/expected_out/multiline_keep.py
+++ b/test/integration/expected_out/multiline_keep.py
@@ -5,5 +5,5 @@ text = f"""
 
 [flake8]
 max-line-length={length}
-inline-quotes="{quotes}\"
+inline-quotes="{quotes}"
 """

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -85,7 +85,7 @@ def test_cli_string_unquoted(capsys, code_in, code_out):
     assert err == ""
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_cli_string_supports_flags(capsys):
     """
     Tests a --string invocation also does additional transformations.

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -500,19 +500,19 @@ def test_equiv_expressions_s(state: State):
     assert eval(out) == eval(s_in)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_concat(state: State):
     s_in = """msg = a + " World\""""
-    s_expected = """msg = f"{a} World\""""
+    s_expected = """msg = f\"{a} World\""""
 
     s_out, count = code_editor.fstringify_concats(s_in, state)
     assert s_out == s_expected
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_concat_two_sides(state: State):
     s_in = """t = 'T is a string of value: ' + val + ' and thats great!'"""
-    s_expected = """t = f"T is a string of value: {val} and thats great!\""""
+    s_expected = """t = f\"T is a string of value: {val} and thats great!\""""
 
     s_out, count = code_editor.fstringify_concats(s_in, state)
     assert s_out == s_expected

--- a/test/test_static_join/test_sj_candidates.py
+++ b/test/test_static_join/test_sj_candidates.py
@@ -9,7 +9,7 @@ from flynt.state import State
 from flynt.static_join.candidates import JoinHound, join_candidates
 
 pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="requires python3.8 or higher"
+    sys.version_info < (3, 9), reason="requires python3.9 or higher"
 )
 
 

--- a/test/test_static_join/test_sj_transformer.py
+++ b/test/test_static_join/test_sj_transformer.py
@@ -8,7 +8,7 @@ import pytest
 from flynt.static_join.transformer import transform_join
 
 pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="requires python3.8 or higher"
+    sys.version_info < (3, 9), reason="requires python3.9 or higher"
 )
 
 

--- a/test/test_str_concat/test_candidates.py
+++ b/test/test_str_concat/test_candidates.py
@@ -18,7 +18,7 @@ def pycode_with_2_concats():
     yield content
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_find_victims_primitives(pycode_with_2_concats: str):
     tree = ast.parse(pycode_with_2_concats)
 
@@ -32,7 +32,7 @@ def test_find_victims_primitives(pycode_with_2_concats: str):
     assert 'a + " World"' in pycode_with_2_concats.split("\n")[v1.start_line]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_find_victims_api(pycode_with_2_concats: str, state: State):
     gen = concat_candidates(pycode_with_2_concats, state)
     lst = list(gen)
@@ -44,7 +44,7 @@ def test_find_victims_api(pycode_with_2_concats: str, state: State):
     assert 'a + " World"' in pycode_with_2_concats.split("\n")[v1.start_line]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="requires python3.8 or higher")
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
 def test_find_victims_parens(state: State):
     txt_in = """print('blah' + (thing - 1))"""
     gen = concat_candidates(txt_in, state)


### PR DESCRIPTION
## Summary
- remove astor dependency and use `ast.unparse` for AST -> code
- implement `_find_py_files` helper since `astor.code_to_ast` was removed
- update docs and CLI text for Python 3.9+
- raise minimum Python version to 3.9
- update tests to require Python 3.9
- fix quoting logic and test failures when using `ast.unparse`
- handle `ast.unparse` failing on invalid f-string conversions

## Testing
- `pre-commit run --files src/flynt/utils/utils.py test/test_edits.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684137e8ec188326b0da792652ea796e