### PR TITLE
Add adversarial case for conversion fields

### DIFF
--- a/examples/issue106_proof.py
+++ b/examples/issue106_proof.py
@@ -1,0 +1,85 @@
+"""Demonstrations for issue #106 about conversion field equivalence.
+
+The f-string conversion specifiers ``!s``, ``!r`` and ``!a`` internally call
+``str()``, ``repr()`` and ``ascii()`` respectively.  This script shows:
+
+* objects with and without ``__format__`` behave identically when using ``!s``,
+  ``!r`` and ``!a`` compared with explicit function calls;
+* overriding the built-in names ``str``/``repr``/``ascii`` breaks this
+  equivalence.
+
+Python's bytecode for ``f"{x!s}"`` uses the ``FORMAT_VALUE`` opcode with a
+conversion flag. This always resolves to the real built-in functions even if the
+names ``str`` or ``repr`` are shadowed in the local scope. Therefore, barring
+such shadowing, ``f"{x!s}"`` is equivalent to ``f"{str(x)}"`` for all objects.
+
+Run this file directly to print the examples.
+"""
+
+
+class Custom:
+    """Defines ``__format__`` in addition to ``__str__`` and ``__repr__``."""
+
+    def __format__(self, spec: str) -> str:
+        return f"formatted({spec})"
+
+    def __str__(self) -> str:
+        return "string"
+
+    def __repr__(self) -> str:
+        return "repr"
+
+
+class WithoutFormat:
+    """Lacks a ``__format__`` implementation."""
+
+    def __str__(self) -> str:
+        return "plain-str"
+
+    def __repr__(self) -> str:
+        return "plain-repr"
+
+
+def demonstrate(obj) -> None:
+    print("object:", obj)
+    print("default f-string:", f"{obj}")
+    print("f'{obj!s}':", f"{obj!s}")
+    print("f'{str(obj)}':", f"{str(obj)}")
+    print("f'{obj!r}':", f"{obj!r}")
+    print("f'{repr(obj)}':", f"{repr(obj)}")
+    print("f'{obj!a}':", f"{obj!a}")
+    print("f'{ascii(obj)}':", f"{ascii(obj)}")
+    print()
+
+
+def shadowed_demo() -> None:
+    print("Shadowing built-ins breaks equivalence:")
+
+    def str(x):  # noqa: A001
+        return "shadowed-str"
+
+    def repr(x):  # noqa: A001
+        return "shadowed-repr"
+
+    def ascii(x):  # noqa: A001
+        return "shadowed-ascii"
+
+    obj = Custom()
+    print("f'{obj!s}':", f"{obj!s}")
+    print("f'{str(obj)}':", f"{str(obj)}")
+    print("f'{obj!r}':", f"{obj!r}")
+    print("f'{repr(obj)}':", f"{repr(obj)}")
+    print("f'{obj!a}':", f"{obj!a}")
+    print("f'{ascii(obj)}':", f"{ascii(obj)}")
+    print()
+
+
+def main() -> None:
+    values = [123, 45.6, "text", Custom(), WithoutFormat()]
+    for value in values:
+        demonstrate(value)
+    shadowed_demo()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_conversion_fields.py
+++ b/test/test_conversion_fields.py
@@ -1,0 +1,66 @@
+import pytest
+
+
+class FormatVsStr:
+    def __format__(self, spec: str) -> str:
+        return f"FMT<{spec}>"
+
+    def __str__(self) -> str:
+        return "STR"
+
+    def __repr__(self) -> str:
+        return "REPR"
+
+
+@pytest.mark.parametrize("obj", [1, 1.5, "text", FormatVsStr()])
+def test_str_equivalence(obj):
+    assert f"{obj!s}" == f"{str(obj)}"
+
+
+@pytest.mark.parametrize("obj", [1, 1.5, "text", FormatVsStr()])
+def test_repr_equivalence(obj):
+    assert f"{obj!r}" == f"{repr(obj)}"
+
+
+@pytest.mark.parametrize("obj", ["\u00e9", FormatVsStr()])
+def test_ascii_equivalence(obj):
+    assert f"{obj!a}" == f"{ascii(obj)}"
+
+
+def test_format_diff():
+    obj = FormatVsStr()
+    assert f"{obj}" != f"{obj!s}"
+    assert f"{obj!s}" == str(obj)
+
+
+class WithoutFormat:
+    def __str__(self) -> str:
+        return "W_STR"
+
+    def __repr__(self) -> str:
+        return "W_REPR"
+
+
+@pytest.mark.parametrize("obj", [WithoutFormat()])
+def test_without_format(obj):
+    # object lacking __format__ uses str for default f-string
+    assert f"{obj}" == str(obj)
+    assert f"{obj!s}" == f"{str(obj)}"
+    assert f"{obj!r}" == f"{repr(obj)}"
+    assert f"{obj!a}" == f"{ascii(obj)}"
+
+
+def test_shadowing_breaks_equivalence():
+    def str(x):  # noqa: A001
+        return "shadow"
+
+    def repr(x):  # noqa: A001
+        return "shadow"
+
+    def ascii(x):  # noqa: A001
+        return "shadow"
+
+    obj = WithoutFormat()
+    assert f"{obj!s}" != f"{str(obj)}"
+    assert f"{obj!r}" != f"{repr(obj)}"
+    assert f"{obj!a}" != f"{ascii(obj)}"


### PR DESCRIPTION
## Summary
- show behaviour for objects lacking `__format__`
- document built-in shadowing and extend proof script
- add tests for object without `__format__` and for shadowed built-ins

## Testing
- `pre-commit run --files examples/issue106_proof.py test/test_conversion_fields.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884bec205cc8326813decea542bf4ca