### PR TITLE
Make report optional and refine output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ From the output of `flynt -h`:
 usage: flynt [-h] [-v | -q] [--no-multiline | -ll LINE_LENGTH]
              [-d | --stdout] [-s] [--no-tp] [--no-tf] [-tc] [-tj]
              [-f] [-a] [-e EXCLUDE [EXCLUDE ...]] [--version]
+             [--report]
              [src ...]
 
-flynt v.0.78
+flynt v.1.0.3
 
 positional arguments:
   src                   source file(s) or directory (or a single `-`
                         to read stdin and output to stdout)
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --verbose         run with verbose output
   -q, --quiet           run without outputting statistics to stdout
@@ -84,7 +85,8 @@ optional arguments:
                         Replace static joins (where the joiner is a
                         string literal and the joinee is a static-
                         length list) with f-strings. Available only
-                        if flynt is installed with a 3.9+ interpreter.
+                        if flynt is installed with a 3.9+
+                        interpreter.
   -f, --fail-on-change  Fail when changing files (for linting
                         purposes)
   -a, --aggressive      Include conversions with potentially changed
@@ -93,6 +95,7 @@ optional arguments:
                         ignore files with given strings in it's
                         absolute path.
   --version             Print the current version number and exit.
+  --report              Show detailed conversion report
 
 ```
 
@@ -104,25 +107,11 @@ Cloning into 'flask'...
 Resolving deltas: 100% (12203/12203), done.
 
 38f9d3a65222:open_source ikkamens$ flynt flask
-Running flynt v.0.40
+Running flynt v.1.0.3
 
-Flynt run has finished. Stats:
-
-Execution time:                            0.789s
-Files modified:                            21
-Character count reduction:                 299 (0.06%)
-
-Per expression type:
-Old style (`%`) expressions attempted:     40/42 (95.2%)
-`.format(...)` calls attempted:            26/33 (78.8%)
-F-string expressions created:              48
-Out of all attempted transforms, 7 resulted in errors.
-To find out specific error messages, use --verbose flag.
-
-_-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_._-_.
-Please run your tests before committing. Did flynt get a perfect conversion? give it a star at:
-~ https://github.com/ikamensh/flynt ~
-Thank you for using flynt. Upgrade more projects and recommend it to your colleagues!
+Modified 21 of 21 files in 0.79s
+Remember to run your tests before committing.
+Thank you for using flynt.
 
 38f9d3a65222:~ ikkamens$
 ```

--- a/src/flynt/api.py
+++ b/src/flynt/api.py
@@ -192,23 +192,25 @@ def fstringify_files(
     total_time = time.time() - start_time
 
     if not state.quiet:
-        _print_report(
-            state,
-            len(files),
-            changed_files,
-            total_charcount_new,
-            total_charcount_original,
-            total_expressions,
-            total_time,
-        )
+        if state.report:
+            _print_report(
+                state,
+                len(files),
+                changed_files,
+                total_charcount_new,
+                total_charcount_original,
+                total_expressions,
+                total_time,
+            )
+        else:
+            _print_summary(len(files), changed_files, total_time)
+            print(farewell_message)
 
     return changed_files
 
 
 farewell_message = (
-    "Please run your tests before committing. Did flynt get a perfect conversion? give it a star at: "
-    "\n~ https://github.com/ikamensh/flynt ~"
-    "\nThank you for using flynt. Upgrade more projects and recommend it to your colleagues!\n"
+    "Remember to run your tests before committing.\nThank you for using flynt.\n"
 )
 
 
@@ -276,6 +278,14 @@ def _print_report(
 
     print(f"\n{'_-_.' * 25}")
     print(farewell_message)
+
+
+def _print_summary(found_files: int, changed_files: int, total_time: float) -> None:
+    """Print a concise conversion summary."""
+    if changed_files:
+        print(f"Modified {changed_files} of {found_files} files in {total_time:.2f}s")
+    else:
+        print(f"No changes made to {found_files} files in {total_time:.2f}s")
 
 
 def fstringify(

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -164,6 +164,12 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
         default=False,
         help="Print the current version number and exit.",
     )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        default=False,
+        help="Show detailed conversion report",
+    )
     args = parser.parse_args(arglist)
     if args.stdout and args.verbose:
         parser.error("--stdout should not be used with -v/--verbose")
@@ -262,4 +268,5 @@ def state_from_args(args) -> State:
         transform_format=args.transform_format,
         transform_join=args.transform_joins,
         transform_percent=args.transform_percent,
+        report=args.report,
     )

--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -13,6 +13,7 @@ class State:
     stdout: bool = False
     multiline: bool = True
     len_limit: Optional[int] = None
+    report: bool = False
     transform_percent: bool = True
     transform_format: bool = True
     transform_concat: bool = False

--- a/test/integration/test_api.py
+++ b/test/integration/test_api.py
@@ -237,7 +237,7 @@ def test_fstringify_files_charcount(tmp_path, monkeypatch):
 
     monkeypatch.setattr(api, "_print_report", fake_print_report)
 
-    state = State()
+    state = State(report=True)
     api.fstringify_files([str(f)], state)
 
     assert captured["orig"] == len(source)

--- a/test/integration/test_cli.py
+++ b/test/integration/test_cli.py
@@ -185,3 +185,15 @@ def test_cli_stdout(capsys, sample_file):
         assert line in expected_lines
     assert not out.strip().endswith(farewell_message.strip())
     assert err == ""
+
+
+def test_cli_report_flag(capsys):
+    folder = os.path.dirname(__file__)
+    source_path = os.path.join(folder, "samples_in", "all_named.py")
+
+    return_code = run_flynt_cli(["--dry-run", "--report", source_path])
+    assert return_code == 0
+
+    out, err = capsys.readouterr()
+    assert "Flynt run has finished. Stats:" in out
+    assert err == ""


### PR DESCRIPTION
## Summary
- remove star message from farewell text and replace with a short reminder
- add `--report` flag for printing the full conversion report
- output a concise summary if `--report` is not given
- update CLI and API tests for the new flag
- refresh README help text and example using `update_readme.py`

## Testing
- `pre-commit run --files README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884bf1884248326ae60466ee2d3dde1