### PR TITLE
Handle str and repr call conversions

### DIFF
--- a/src/flynt/utils/utils.py
+++ b/src/flynt/utils/utils.py
@@ -87,6 +87,18 @@ def ast_formatted_value(
             "values starting with '{' are better left not transformed.",
         )
 
+    if (
+        fmt_str in (None, "")
+        and conversion is None
+        and isinstance(val, ast.Call)
+        and isinstance(val.func, ast.Name)
+        and val.func.id in {"str", "repr"}
+        and not val.keywords
+        and len(val.args) == 1
+    ):
+        conversion = f"!{'s' if val.func.id == 'str' else 'r'}"
+        val = val.args[0]
+
     if fmt_str:
         format_spec = ast.JoinedStr([ast_string_node(fmt_str)])
     else:

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -99,8 +99,8 @@ def test_percent_list(state: State):
 
 
 def test_percent_str_call(state: State):
-    s_in = """'%s' % str(var)"""
-    s_expected = """f'{var!s}'"""
+    s_in = """'%s %s' % (str(var), uno)"""
+    s_expected = """f'{var!s} {uno}'"""
 
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -98,6 +98,22 @@ def test_percent_list(state: State):
     assert s_out == s_expected
 
 
+def test_percent_str_call(state: State):
+    s_in = """'%s' % str(var)"""
+    s_expected = """f'{var!s}'"""
+
+    s_out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert s_out == s_expected
+
+
+def test_percent_repr_call(state: State):
+    s_in = """'%s' % repr(var)"""
+    s_expected = """f'{var!r}'"""
+
+    s_out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert s_out == s_expected
+
+
 def test_part_of_concat(state: State):
     s_in = """print('blah{}'.format(thing) + 'blah' + otherThing + "is %f" % x)"""
     s_expected = """print(f'blah{thing}' + 'blah' + otherThing + f"is {x:f}")"""
@@ -117,6 +133,22 @@ def test_one_string(state: State):
 def test_nonatomic(state: State):
     s_in = """'blah{0}'.format(thing - 1)"""
     s_expected = """f'blah{thing - 1}'"""
+
+    s_out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert s_out == s_expected
+
+
+def test_format_str_call(state: State):
+    s_in = """'{}'.format(str(var))"""
+    s_expected = """f'{var!s}'"""
+
+    s_out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert s_out == s_expected
+
+
+def test_format_repr_call(state: State):
+    s_in = """'{}'.format(repr(var))"""
+    s_expected = """f'{var!r}'"""
 
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected


### PR DESCRIPTION
## Summary
- translate `str()` and `repr()` format calls to use `!s` and `!r`
- test handling of `str()`/`repr()` in `%` and `.format` conversions

## Testing
- `pre-commit run --files src/flynt/utils/utils.py test/test_edits.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884cc1198dc8326a0b923faada6153a