### PR TITLE
Preserve unicode escapes

### DIFF
--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -157,12 +157,8 @@ class CodeEditor:
                 return
 
         snippet = self.code_in_chunk(chunk)
-        try:
-            quote_type = get_quote_type(snippet)
-            escape_map = unicode_escape_map(snippet)
-        except FlyntException:
-            quote_type = qt.double
-            escape_map = {}
+        quote_type = get_quote_type(snippet)
+        escape_map = unicode_escape_map(snippet)
 
         converted, changed = self.transform_func(chunk.node, quote_type=quote_type)
         if changed and escape_map:

--- a/src/flynt/code_editor.py
+++ b/src/flynt/code_editor.py
@@ -157,8 +157,13 @@ class CodeEditor:
                 return
 
         snippet = self.code_in_chunk(chunk)
-        quote_type = get_quote_type(snippet)
-        escape_map = unicode_escape_map(snippet)
+        # try/except only needed for python 3.9 due to quote issues
+        try:
+            quote_type = get_quote_type(snippet)
+            escape_map = unicode_escape_map(snippet)
+        except FlyntException:
+            quote_type = qt.double
+            escape_map = {}
 
         converted, changed = self.transform_func(chunk.node, quote_type=quote_type)
         if changed and escape_map:

--- a/test/integration/expected_out/unicode_escape.py
+++ b/test/integration/expected_out/unicode_escape.py
@@ -1,0 +1,1 @@
+print(f"Feels like: {data['main']['feels_like']}\\u00B0F")

--- a/test/integration/samples_in/unicode_escape.py
+++ b/test/integration/samples_in/unicode_escape.py
@@ -1,0 +1,1 @@
+print("Feels like: {}\\u00B0F".format(data["main"]["feels_like"]))

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -54,6 +54,7 @@ def test_unicode_chunk_no_token_error():
 
 
 def test_unicode_escape_preserved():
+    """Unicode escaped characters should be kept as such. """
     code = 'print("Feels like: {}\\u00B0F".format(data["main"]["feels_like"]))'
     state = State()
     chunk = next(iter(call_candidates(code, state)))

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -54,7 +54,7 @@ def test_unicode_chunk_no_token_error():
 
 
 def test_unicode_escape_preserved():
-    """Unicode escaped characters should be kept as such. """
+    """Unicode escaped characters should be kept as such."""
     code = 'print("Feels like: {}\\u00B0F".format(data["main"]["feels_like"]))'
     state = State()
     chunk = next(iter(call_candidates(code, state)))

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -51,3 +51,18 @@ def test_unicode_chunk_no_token_error():
 
     assert snippet == '"Feels l°°ike: {}ﭗ°°\u1234F".format(data["main"]["feels_like"])'
     assert contains_comment(snippet) is False
+
+
+def test_unicode_escape_preserved():
+    code = 'print("Feels like: {}\\u00B0F".format(data["main"]["feels_like"]))'
+    state = State()
+    chunk = next(iter(call_candidates(code, state)))
+    editor = CodeEditor(
+        code,
+        state.len_limit,
+        lambda _=None: [chunk],
+        partial(transform_chunk, state=state),
+    )
+    out, count = editor.edit()
+    assert out == "print(f\"Feels like: {data['main']['feels_like']}\\u00B0F\")"
+    assert count == 1


### PR DESCRIPTION
## Summary
- add helpers for preserving unicode escape sequences
- apply escape preservation during chunk editing
- test that escape sequences remain after conversion
- add integration test for unicode escape handling

## Testing
- `pre-commit run --files src/flynt/utils/utils.py src/flynt/code_editor.py test/test_code_editor.py test/integration/samples_in/unicode_escape.py test/integration/expected_out/unicode_escape.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688630d91dac8326bd1922a00d509398