### PR TITLE
Fix concatenation transform for constant chains

### DIFF
--- a/src/flynt/string_concat/transformer.py
+++ b/src/flynt/string_concat/transformer.py
@@ -14,14 +14,17 @@ from flynt.utils.utils import (
 
 def unpack_binop(node: ast.BinOp) -> List[ast.AST]:
     assert isinstance(node, ast.BinOp)
-    result = []
+    if not isinstance(node.op, ast.Add):
+        return [node]
 
-    if isinstance(node.left, ast.BinOp):
+    result: List[ast.AST] = []
+
+    if isinstance(node.left, ast.BinOp) and isinstance(node.left.op, ast.Add):
         result.extend(unpack_binop(node.left))
     else:
         result.append(node.left)
 
-    if isinstance(node.right, ast.BinOp):
+    if isinstance(node.right, ast.BinOp) and isinstance(node.right.op, ast.Add):
         result.extend(unpack_binop(node.right))
     else:
         result.append(node.right)
@@ -41,19 +44,19 @@ class ConcatTransformer(ast.NodeTransformer):
         if not is_string_concat(node):
             return self.generic_visit(node)
         self.counter += 1
-        left, right = node.left, node.right
-        left = self.visit(left)
-        right = self.visit(right)
+        parts_raw = unpack_binop(node)
+        visited_parts = [self.visit(p) for p in parts_raw]
 
-        if not check_sns_depth(left) or not check_sns_depth(right):
-            node.left = left
-            node.right = right
-            return node
+        if any(not check_sns_depth(p) for p in visited_parts):
+            res = visited_parts[0]
+            for sub in visited_parts[1:]:
+                res = ast.BinOp(left=res, op=ast.Add(), right=sub)
+            return res
 
-        parts = []
-        for p in [left, right]:
+        parts: List[ast.AST] = []
+        for p in visited_parts:
             if isinstance(p, ast.JoinedStr):
-                parts += p.values
+                parts.extend(p.values)
             else:
                 parts.append(p)
 

--- a/test/integration/expected_out_concat/cr_lf_concat.py
+++ b/test/integration/expected_out_concat/cr_lf_concat.py
@@ -1,0 +1,3 @@
+CR = '\r'
+LF = '\n'
+writer.write(f"{CR}{LF}Goodbye{CR}{LF}")

--- a/test/integration/samples_in_concat/cr_lf_concat.py
+++ b/test/integration/samples_in_concat/cr_lf_concat.py
@@ -1,0 +1,3 @@
+CR = '\r'
+LF = '\n'
+writer.write(CR + LF + "Goodbye" + CR + LF)


### PR DESCRIPTION
## Summary
- unpack `BinOp` only for `+` operations
- flatten all `+` segments before building f-string
- add regression test for CR/LF concatenation

## Testing
- `pre-commit run --files src/flynt/string_concat/transformer.py test/integration/samples_in_concat/cr_lf_concat.py test/integration/expected_out_concat/cr_lf_concat.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688631c9666c8326a518201d77310145