### PR TITLE
Fix unicode escape preservation when mixed with literal chars

### DIFF
--- a/src/flynt/utils/utils.py
+++ b/src/flynt/utils/utils.py
@@ -3,7 +3,7 @@ import codecs
 import io
 import re
 import tokenize
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from flynt.exceptions import ConversionRefused
 from flynt.linting.fstr_lint import FstrInliner
@@ -164,8 +164,14 @@ unicode_escape_re = re.compile(
 )
 
 
-def unicode_escape_map(literal: str) -> Dict[str, str]:
-    """Return mapping of characters to their unicode escape sequences."""
+def unicode_escape_map(literal: str) -> Dict[str, List[str]]:
+    """Return mapping of characters to all unicode escape sequences used for them.
+
+    Multiple occurrences of the same character may appear both escaped and
+    unescaped in the literal.  This function preserves the order of escapes so
+    that they can later be re-applied only to the characters that were escaped
+    originally.
+    """
     quote = get_quote_type(literal)
     if quote is None:
         return {}
@@ -173,23 +179,31 @@ def unicode_escape_map(literal: str) -> Dict[str, str]:
     while idx < len(literal) and literal[idx] in "furbFURB":
         idx += 1
     body = literal[idx + len(quote) : -len(quote)]
-    mapping: Dict[str, str] = {}
+    mapping: Dict[str, List[str]] = {}
     for m in unicode_escape_re.finditer(body):
         esc = m.group(0)
         try:
             char = codecs.decode(esc, "unicode_escape")
         except Exception:  # noqa: S112
             continue
-        mapping[char] = esc
+        mapping.setdefault(char, []).append(esc)
     return mapping
 
 
-def apply_unicode_escape_map(code: str, mapping: Dict[str, str]) -> str:
-    """Replace characters in ``code`` with their escape sequences."""
+def apply_unicode_escape_map(code: str, mapping: Dict[str, List[str]]) -> str:
+    """Replace characters in ``code`` with their original escape sequences."""
     if not mapping:
         return code
     pattern = "[" + "".join(re.escape(c) for c in mapping) + "]"
-    return re.sub(pattern, lambda m: mapping[m.group(0)], code)
+
+    def repl(match: re.Match[str]) -> str:
+        char = match.group(0)
+        escapes = mapping.get(char)
+        if escapes:
+            return escapes.pop(0)
+        return char
+
+    return re.sub(pattern, repl, code)
 
 
 def contains_unicode_escape(code: str) -> bool:

--- a/test/test_code_editor.py
+++ b/test/test_code_editor.py
@@ -68,7 +68,7 @@ def test_unicode_escape_preserved():
     assert out == "print(f\"Feels like: {data['main']['feels_like']}\\u00B0F\")"
     assert count == 1
 
-@pytest.mark.xfail
+
 def test_unicode_escape_mixed_preserved():
     """Unicode escaped characters should be kept as such."""
     code = 'print("Feels like: {}\\u00B0F°".format(data["main"]["feels_like"]))'


### PR DESCRIPTION
## Summary
- handle multiple occurrences of escaped unicode characters
- allow `test_unicode_escape_mixed_preserved` to pass

## Testing
- `pre-commit run --files src/flynt/utils/utils.py test/test_code_editor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886464a8a1483269d4e483167627ae0