### PR TITLE
Handle concats with backslashes

### DIFF
--- a/test/integration/expected_out_concat/literals_only.py
+++ b/test/integration/expected_out_concat/literals_only.py
@@ -1,1 +1,2 @@
 res = "here\\there"
+

--- a/test/integration/expected_out_concat/regex_sub.py
+++ b/test/integration/expected_out_concat/regex_sub.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import re
+
+
+individual_tests = [
+    re.sub(r"\.py$", "", test) + ".py" for test in ["a.py", "b.py", "c*"] if not test.endswith('*')
+]
+

--- a/test/integration/samples_in_concat/literals_only.py
+++ b/test/integration/samples_in_concat/literals_only.py
@@ -1,1 +1,2 @@
 res = "here" + r"\there"
+

--- a/test/integration/samples_in_concat/regex_sub.py
+++ b/test/integration/samples_in_concat/regex_sub.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import re
+
+
+individual_tests = [
+    re.sub(r"\.py$", "", test) + ".py" for test in ["a.py", "b.py", "c*"] if not test.endswith('*')
+]
+

--- a/test/test_str_concat/test_transformer.py
+++ b/test/test_str_concat/test_transformer.py
@@ -155,7 +155,6 @@ def test_parens():
 def test_concat_only_literals():
     txt = '"here" + r"\\there"'
     expected = '"here\\\\there"'
-
     new, changed = transform_concat_from_str(txt)
 
     assert changed
@@ -168,6 +167,5 @@ noexc_out = """individual_tests = [f"{re.sub(r"\.py$", "", test)}.py" for test i
 
 def test_noexc():
     new, changed = transform_concat_from_str(noexc_in)
-    # TODO this doesn't produce expected output - number of escapes is surprising
-    # assert changed
-    # assert new == noexc_out
+    assert not changed
+    assert new == ""


### PR DESCRIPTION
## Summary
- avoid transforming concatenations with backslashes only when they would create an f-string
- keep constant-only concatenations working
- update regression tests

## Testing
- `pre-commit run --files src/flynt/string_concat/transformer.py test/integration/expected_out_concat/literals_only.py test/test_str_concat/test_transformer.py test/integration/samples_in_concat/regex_sub.py test/integration/expected_out_concat/regex_sub.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867547c5f48326aa353f87761ad52d