### PR TITLE
Adjust aggressive %d behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,10 @@ print( f"|{111:5}|{999_999:5}|{77:5}|" )
 """
 ```
 
-* %d format specifier is transformed only in `--aggressive` mode, 
-and will result in `"%d" % var` -> `f"{int(var)}"`. See https://github.com/ikamensh/flynt/issues/59.
+* %d format specifier is transformed only in `--aggressive` mode,
+  resulting in `"%d" % var` -> `f"{int(var)}"`.
+  Use `-aa` to omit the `int()` call.
+  See https://github.com/ikamensh/flynt/issues/59.
 
 * added short versions to other flags:
 ```

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ From the output of `flynt -h`:
 
 <!-- begin-options -->
 ```
-usage: flynt [-h] [-v | -q] [--no-multiline | -ll LINE_LENGTH] [-d |
-             --stdout] [-s] [--no-tp] [--no-tf] [-tc] [-tj] [-f]
-             [-a] [-e EXCLUDE [EXCLUDE ...]] [--version] [--report]
+usage: flynt [-h] [-v | -q] [--no-multiline | -ll LINE_LENGTH]
+             [-d | --stdout] [-s] [--no-tp] [--no-tf] [-tc] [-tj]
+             [-f] [-a] [-e EXCLUDE [EXCLUDE ...]] [--version]
+             [--report]
              [src ...]
 
 flynt v.1.0.3

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -135,9 +135,12 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "-a",
         "--aggressive",
-        action="store_true",
-        default=False,
-        help="Include conversions with potentially changed behavior.",
+        action="count",
+        default=0,
+        help=(
+            "Include conversions with potentially changed behavior. "
+            "Use -aa to omit int() wrapping for %%d conversions."
+        ),
     )
 
     parser.add_argument(

--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -8,7 +8,7 @@ from typing import Optional
 class State:
     # -- Options
     quiet: bool = False
-    aggressive: bool = False
+    aggressive: int = 0
     dry_run: bool = False
     stdout: bool = False
     multiline: bool = True

--- a/src/flynt/transform/FstringifyTransformer.py
+++ b/src/flynt/transform/FstringifyTransformer.py
@@ -34,7 +34,7 @@ class FstringifyTransformer(ast.NodeTransformer):
 
             result_node = joined_string(
                 node,
-                aggressive=self.state.aggressive,
+                aggressive=self.state.aggressive >= 1,
             )
             self.visit(result_node)
             self.counter += 1

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -42,7 +42,7 @@ def test_string_specific_len_right_aligned(state: State):
     s_in = """'%5s' % CLASS_NAMES[labels[j]]"""
     s_expected = """f'{CLASS_NAMES[labels[j]]:>5}'"""
 
-    state.aggressive = True
+    state.aggressive = 1
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
@@ -51,7 +51,7 @@ def test_string_specific_len_left_aligned(state: State):
     s_in = """'%-5s' % CLASS_NAMES[labels[j]]"""
     s_expected = """f'{CLASS_NAMES[labels[j]]:5}'"""
 
-    state.aggressive = True
+    state.aggressive = 1
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
@@ -60,7 +60,7 @@ def test_dont_wrap_int(state: State):
     s_in = """print('Int cast %d' % int(18.81))"""
     s_expected = """print(f'Int cast {int(18.81)}')"""
 
-    state.aggressive = True
+    state.aggressive = 1
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
@@ -69,7 +69,7 @@ def test_dont_wrap_len(state: State):
     s_in = """print('List length %d' % len(sys.argv))"""
     s_expected = """print(f'List length {len(sys.argv)}')"""
 
-    state.aggressive = True
+    state.aggressive = 1
     s_out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert s_out == s_expected
 
@@ -402,7 +402,14 @@ def test_percent_dict(state: State):
 def test_percent_dict_fmt(state: State):
     s_in = """a = '%(?)ld world' % {'?': var}"""
     s_expected = """a = f'{int(var)} world'"""
-    state.aggressive = True
+    state.aggressive = 1
+    assert code_editor.fstringify_code_by_line(s_in, state)[0] == s_expected
+
+
+def test_percent_dict_fmt_extra_aggressive(state: State):
+    s_in = """a = '%(?)ld world' % {'?': var}"""
+    s_expected = """a = f'{var} world'"""
+    state.aggressive = 2
     assert code_editor.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
@@ -426,7 +433,7 @@ def test_percent_dict_reused_key_noop(state: State):
 def test_percent_dict_reused_key_aggressive(state: State):
     s_expected = """a = f'{var} {var}'"""
 
-    state.aggressive = True
+    state.aggressive = 1
     assert (
         code_editor.fstringify_code_by_line(percent_dict_reused_key, state)[0]
         == s_expected
@@ -466,7 +473,16 @@ def test_legacy_fmtspec(state: State):
     s_in = """d = '%i' % var"""
     s_expected = """d = f'{int(var)}'"""
 
-    state.aggressive = True
+    state.aggressive = 1
+    out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert out == s_expected
+
+
+def test_legacy_fmtspec_extra_aggressive(state: State):
+    s_in = """d = '%i' % var"""
+    s_expected = """d = f'{var}'"""
+
+    state.aggressive = 2
     out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert out == s_expected
 
@@ -501,7 +517,7 @@ def test_width_spec(state: State):
     s_in = "{'r': '%03f' % row_idx}"
     s_expected = """{'r': f'{row_idx:03f}'}"""
 
-    state.aggressive = True
+    state.aggressive = 1
     assert code_editor.fstringify_code_by_line(s_in, state)[0] == s_expected
 
 
@@ -712,7 +728,7 @@ def test_110(state: State):
     """Test for issue #110 on github"""
     s_in = "'{conn.login}:{conn.password}@'.format(conn=x)"
     expected_out = "f'{x.login}:{x.password}@'"
-    state.aggressive = True
+    state.aggressive = 1
     out, count = code_editor.fstringify_code_by_line(s_in, state)
     assert count == 1
     assert out == expected_out


### PR DESCRIPTION
## Summary
- switch `-a/--aggressive` to count occurrences instead of a numeric value
- omit `int()` wrapping for `%d` when using `-aa`
- update README help output and changelog
- trim excessive formatting in percent transformer

## Testing
- `pre-commit run --files src/flynt/cli.py src/flynt/state.py src/flynt/transform/FstringifyTransformer.py src/flynt/transform/percent_transformer.py test/test_edits.py CHANGELOG.md README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886641070e0832692cf5ad518cf9ea2