### PR TITLE
Support notebook conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ From the output of `flynt -h`:
 ```
 usage: flynt [-h] [-v | -q] [--no-multiline | -ll LINE_LENGTH]
              [-d | --stdout] [-s] [--no-tp] [--no-tf] [-tc] [-tj]
-             [-f] [-a] [-e EXCLUDE [EXCLUDE ...]] [--version]
-             [--report]
+             [-f] [-a] [-e EXCLUDE [EXCLUDE ...]] [--notebook]
+             [--version] [--report]
              [src ...]
 
 flynt v.1.0.3
@@ -52,7 +52,7 @@ options:
   -v, --verbose         run with verbose output
   -q, --quiet           run without outputting statistics to stdout
   --no-multiline        convert only single line expressions
-  -ll, --line-length LINE_LENGTH
+  -ll LINE_LENGTH, --line-length LINE_LENGTH
                         for expressions spanning multiple lines,
                         convert only if the resulting single line
                         will fit into the line length limit. Default
@@ -90,10 +90,13 @@ options:
   -f, --fail-on-change  Fail when changing files (for linting
                         purposes)
   -a, --aggressive      Include conversions with potentially changed
-                        behavior.
-  -e, --exclude EXCLUDE [EXCLUDE ...]
+                        behavior. Use -aa to omit int() wrapping for
+                        %d conversions.
+  -e EXCLUDE [EXCLUDE ...], --exclude EXCLUDE [EXCLUDE ...]
                         ignore files with given strings in it's
                         absolute path.
+  --notebook            Also search and transform Jupyter notebooks
+                        (.ipynb files)
   --version             Print the current version number and exit.
   --report              Show detailed conversion report
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ From the output of `flynt -h`:
 
 <!-- begin-options -->
 ```
-usage: flynt [-h] [-v | -q] [--no-multiline | -ll LINE_LENGTH]
-             [-d | --stdout] [-s] [--no-tp] [--no-tf] [-tc] [-tj]
-             [-f] [-a] [-e EXCLUDE [EXCLUDE ...]] [--notebook]
-             [--version] [--report]
+usage: flynt [-h] [-v | -q] [--no-multiline | -ll LINE_LENGTH] [-d |
+             --stdout] [-s] [--no-tp] [--no-tf] [-tc] [-tj] [-f]
+             [-a] [-e EXCLUDE [EXCLUDE ...]] [-nb] [--version]
+             [--report]
              [src ...]
 
 flynt v.1.0.3
@@ -52,7 +52,7 @@ options:
   -v, --verbose         run with verbose output
   -q, --quiet           run without outputting statistics to stdout
   --no-multiline        convert only single line expressions
-  -ll LINE_LENGTH, --line-length LINE_LENGTH
+  -ll, --line-length LINE_LENGTH
                         for expressions spanning multiple lines,
                         convert only if the resulting single line
                         will fit into the line length limit. Default
@@ -92,11 +92,12 @@ options:
   -a, --aggressive      Include conversions with potentially changed
                         behavior. Use -aa to omit int() wrapping for
                         %d conversions.
-  -e EXCLUDE [EXCLUDE ...], --exclude EXCLUDE [EXCLUDE ...]
+  -e, --exclude EXCLUDE [EXCLUDE ...]
                         ignore files with given strings in it's
                         absolute path.
-  --notebook            Also search and transform Jupyter notebooks
-                        (.ipynb files)
+  -nb, --notebook       Also search and transform Jupyter notebooks
+                        (.ipynb files). Warning: feature in alpha
+                        and was not thoroughly tested.
   --version             Print the current version number and exit.
   --report              Show detailed conversion report
 

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -152,6 +152,13 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
     )
 
     parser.add_argument(
+        "--notebook",
+        action="store_true",
+        default=False,
+        help="Also search and transform Jupyter notebooks (.ipynb files)",
+    )
+
+    parser.add_argument(
         "src",
         action="store",
         nargs="*",
@@ -272,4 +279,5 @@ def state_from_args(args) -> State:
         transform_join=args.transform_joins,
         transform_percent=args.transform_percent,
         report=args.report,
+        process_notebooks=args.notebook,
     )

--- a/src/flynt/cli.py
+++ b/src/flynt/cli.py
@@ -152,10 +152,11 @@ def run_flynt_cli(arglist: Optional[List[str]] = None) -> int:
     )
 
     parser.add_argument(
+        "-nb",
         "--notebook",
         action="store_true",
         default=False,
-        help="Also search and transform Jupyter notebooks (.ipynb files)",
+        help="Also search and transform Jupyter notebooks (.ipynb files). Warning: feature in alpha and was not thoroughly tested.",
     )
 
     parser.add_argument(

--- a/src/flynt/state.py
+++ b/src/flynt/state.py
@@ -18,6 +18,7 @@ class State:
     transform_format: bool = True
     transform_concat: bool = False
     transform_join: bool = False
+    process_notebooks: bool = False
 
     # -- Statistics
     percent_candidates: int = 0

--- a/test/integration/expected_out/simple.ipynb
+++ b/test/integration/expected_out/simple.ipynb
@@ -1,0 +1,12 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "source": ["# Title"]},
+  {"cell_type": "code", "source": ["print(f'{42} ')\n"]},
+  {"cell_type": "code", "source": ["already = f'{42}'\n"]},
+  {"cell_type": "code", "source": ["print('no change')\n"]},
+  {"cell_type": "markdown", "source": ["End"]}
+ ],
+ "metadata": {"language_info": {"name": "python"}},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/test/integration/samples_in/simple.ipynb
+++ b/test/integration/samples_in/simple.ipynb
@@ -1,0 +1,12 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "source": ["# Title"]},
+  {"cell_type": "code", "source": ["print('{} '.format(42))\n"]},
+  {"cell_type": "code", "source": ["already = f'{42}'\n"]},
+  {"cell_type": "code", "source": ["print('no change')\n"]},
+  {"cell_type": "markdown", "source": ["End"]}
+ ],
+ "metadata": {"language_info": {"name": "python"}},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/test/integration/test_notebook_file.py
+++ b/test/integration/test_notebook_file.py
@@ -1,0 +1,31 @@
+import json
+import os
+import shutil
+
+
+from flynt.api import _fstringify_file
+from flynt.state import State
+
+
+def test_sample_notebook(tmp_path):
+    """Integration test for notebook conversion.
+
+    Ensures that with ``process_notebooks`` enabled only code cells are
+    transformed, while markdown cells and already f-string formatted code stay
+    untouched.
+    """
+    folder = os.path.dirname(__file__)
+    src = os.path.join(folder, "samples_in", "simple.ipynb")
+    expected = os.path.join(folder, "expected_out", "simple.ipynb")
+    nb_path = tmp_path / "simple.ipynb"
+    shutil.copy2(src, nb_path)
+
+    result = _fstringify_file(str(nb_path), State(process_notebooks=True))
+    assert result and result.n_changes == 1
+
+    with open(nb_path) as f:
+        converted = json.load(f)
+    with open(expected) as f:
+        expect = json.load(f)
+
+    assert converted == expect


### PR DESCRIPTION
## Summary
- support converting Jupyter notebooks with new `--notebook` flag
- parse notebooks when requested in API
- expose state option `process_notebooks`
- update README with new flag
- test notebook handling
- add integration test for `.ipynb` files

## Testing
- `pre-commit run --files test/integration/test_notebook_file.py test/integration/samples_in/simple.ipynb test/integration/expected_out/simple.ipynb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688761f2ebf083268172aef595a98c56