### PR TITLE
Don't convert %c percent formatting to f-strings (fixes #253)

### DIFF
--- a/src/flynt/transform/percent_transformer.py
+++ b/src/flynt/transform/percent_transformer.py
@@ -69,6 +69,16 @@ def formatted_value(
     *,
     aggressive: int = 0,
 ) -> Union[ast.FormattedValue, ast.Constant]:
+    if fmt_spec == "c":
+        # Percent ``%c`` accepts an integer *or* a single-character string,
+        # but the f-string ``:c`` format spec only accepts an integer. As we
+        # cannot know the argument type, converting ``%c`` is unsafe and would
+        # crash at runtime for string arguments. See
+        # https://github.com/ikamensh/flynt/issues/253
+        raise ConversionRefused(
+            "Skipping %c formatting - fstrings behave differently from % formatting.",
+        )
+
     if fmt_spec in integer_specificers:
         fmt_prefix = fmt_prefix.replace(".", "0")
 

--- a/test/test_edits.py
+++ b/test/test_edits.py
@@ -620,6 +620,37 @@ def test_unknown_mod_percend_dictionary(state: State):
     assert out == s_in
 
 
+def test_percent_c_string_no_change(state: State):
+    """Regression for https://github.com/ikamensh/flynt/issues/253
+
+    Percent ``%c`` accepts an integer *or* a single-character string, but the
+    f-string ``:c`` format spec only accepts an integer. Converting
+    ``"%c" % letter`` (str) to ``f"{letter:c}"`` therefore crashes at runtime
+    with ``ValueError: Unknown format code 'c'``. Since flynt cannot know the
+    argument type, it must leave ``%c`` formatting unchanged.
+    """
+    letter = "a"  # noqa: F841
+
+    s_in = '"%c: " % letter'
+
+    out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert count == 0
+    assert out == s_in
+    # The (unchanged) output must still run without raising.
+    assert eval(out) == eval(s_in)
+
+
+def test_percent_c_no_change_aggressive(state: State):
+    """``%c`` is unsafe to convert even in aggressive mode (see issue #253)."""
+
+    s_in = '"%c" % letter'
+
+    state.aggressive = 2
+    out, count = code_editor.fstringify_code_by_line(s_in, state)
+    assert count == 0
+    assert out == s_in
+
+
 s_in_mixed_quotes = """'one is {} '"and two is {}".format(one, two)"""
 
 


### PR DESCRIPTION
Fixes #253

### Root cause

`%c` in percent formatting accepts **an integer or a single-character string** (see the [printf-style docs](https://docs.python.org/3/library/stdtypes.html#old-string-formatting)). The f-string `:c` format spec only accepts **an integer** — it converts an int to the corresponding unicode character (see the [format spec mini-language](https://docs.python.org/3/library/string.html#format-specification-mini-language)).

In `src/flynt/transform/percent_transformer.py`, `formatted_value()` had no special handling for `c`: it is not in `conversion_methods`, not in `integer_specificers`, and `translate_conversion_types.get("c", "c")` leaves it as `"c"`, so it fell through to `ast_formatted_value(val, fmt_str=fmt_prefix + fmt_spec)`, producing `{val:c}`. For a string argument the rewritten f-string raises at runtime.

### Reproduction

```console
$ echo 'letter="a"; print("%c: " % letter)' > test.py
$ python test.py
a:
$ flynt test.py
Running flynt v.1.0.6
Modified 1 of 1 files in 0.00s
$ cat test.py
letter="a"; print(f"{letter:c}: ")
$ python test.py
Traceback (most recent call last):
  File "test.py", line 1, in <module>
    letter="a"; print(f"{letter:c}: ")
                        ^^^^^^^^^^
ValueError: Unknown format code 'c' for object of type 'str'
```

With this change flynt leaves the code untouched:

```console
$ flynt test.py
Running flynt v.1.0.6
No changes made to 1 file in 0.00s
$ cat test.py
letter="a"; print("%c: " % letter)
$ python test.py
a:
```

### Fix

Refuse the conversion for `%c` by raising `ConversionRefused` at the top of `formatted_value()`. Because flynt cannot know the argument type, the only safe behaviour is to leave `%c` formatting alone. This mirrors how the existing code already refuses other unsafe specifiers (e.g. `%d` when the argument is not a known-`int` call). `ConversionRefused` is already caught in `transform_chunk()`, so a `%c` chunk simply results in no change.

`formatted_value()` is the single choke point through which all percent conversion paths flow (tuple, list, dict and generic), so the one guard covers every case. `%c` is unsafe regardless of the `--aggressive` level, so the guard is unconditional.

The change is 10 lines and adds no new imports.

### Tests

Added to `test/test_edits.py` (the existing style, using `code_editor.fstringify_code_by_line`):

- `test_percent_c_string_no_change` — asserts `"%c: " % letter` is left unchanged and that the (unchanged) output still evaluates without raising.
- `test_percent_c_no_change_aggressive` — asserts `%c` is also left unchanged under `aggressive=2`.

Both tests fail on the unmodified code (flynt wrongly converts `%c`, `count == 1`) and pass with the fix. The full suite stays green: `421 passed, 1 skipped, 1 xfailed`. `pre-commit` (ruff-format, ruff, codespell, mypy) passes on the changed files.

---

Disclosure: prepared with AI assistance; reviewed and verified locally.
